### PR TITLE
Add optional clean step to ARM build script

### DIFF
--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Usage: build_arm.sh [--clean|--no-clean]
+#   --clean     Remove previous build directories before building (default)
+#   --no-clean  Skip removal of build directories
+
+clean=true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --clean)
+      clean=true
+      shift
+      ;;
+    --no-clean)
+      clean=false
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--clean|--no-clean]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 # Validate required tools
 CROSS_COMPILE_ARM=${CROSS_COMPILE_ARM:-arm-linux-gnueabihf-}
 CROSS_COMPILE_ARM64=${CROSS_COMPILE_ARM64:-aarch64-linux-gnu-}
@@ -34,7 +56,14 @@ make -C ham
 )
 
 # Start from a clean state
-rm -rf obj
+if [ "$clean" = true ]; then
+  # Remove common build directories if they exist
+  for dir in obj lib out; do
+    if [ -d "$dir" ]; then
+      rm -rf "$dir"
+    fi
+  done
+fi
 
 # Configure for ARM using setup script
 export CROSS_COMPILE_ARM CROSS_COMPILE_ARM64


### PR DESCRIPTION
## Summary
- add `--clean` flag to `scripts/build_arm.sh` with default clean behavior
- guard `rm -rf` calls and remove common build directories conditionally
- document flag usage in script comments

## Testing
- `bash -n scripts/build_arm.sh`
- `shellcheck scripts/build_arm.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c556c46808832faf96d93c50dbd148