### PR TITLE
Add QEMU test option to ARM build script

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,14 @@
-This project re-introduces Rust for the L4Re microkernel. 
+This project re-introduces Rust for the L4Re microkernel.
 
-Starting point was the work of the project [rustl4re](https://github.com/humenda/rustl4re). 
+Starting point was the work of the project [rustl4re](https://github.com/humenda/rustl4re).
+
+## Building for ARM
+
+Use `scripts/build_arm.sh` to build the project. By default, previous build
+artifacts are removed before compilation. Passing `--no-clean` skips this
+cleanup.
+
+The script also accepts a `--test` flag which performs a brief QEMU boot using
+the generated image `obj/l4/arm64/images/bootstrap_hello_arm_virt.elf`. The
+script aborts if the QEMU run fails, providing a quick smoke test of the
+build.

--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: build_arm.sh [--clean|--no-clean]
+# Usage: build_arm.sh [--clean|--no-clean] [--test]
 #   --clean     Remove previous build directories before building (default)
 #   --no-clean  Skip removal of build directories
+#   --test      Run a minimal QEMU boot test after building
 
 clean=true
+run_test=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --clean)
@@ -16,8 +18,12 @@ while [[ $# -gt 0 ]]; do
       clean=false
       shift
       ;;
+    --test)
+      run_test=true
+      shift
+      ;;
     *)
-      echo "Usage: $0 [--clean|--no-clean]" >&2
+      echo "Usage: $0 [--clean|--no-clean] [--test]" >&2
       exit 1
       ;;
   esac
@@ -79,3 +85,20 @@ mkdir -p "$out_dir"
 find obj -type f \( -name '*.rlib' -o -name '*.elf' -o -name '*.img' -o -name '*.image' \) -exec cp {} "$out_dir" \;
 
 echo "Artifacts placed in $out_dir"
+
+if [ "$run_test" = true ]; then
+  boot_img="obj/l4/arm64/images/bootstrap_hello_arm_virt.elf"
+  if [ ! -f "$boot_img" ]; then
+    echo "Boot image $boot_img not found" >&2
+    exit 1
+  fi
+  if ! command -v qemu-system-aarch64 >/dev/null 2>&1; then
+    echo "qemu-system-aarch64 not found" >&2
+    exit 1
+  fi
+  echo "Running QEMU test..."
+  if ! timeout 5s qemu-system-aarch64 -machine virt -cpu cortex-a57 -nographic -serial mon:stdio -kernel "$boot_img" >/dev/null; then
+    echo "QEMU test run failed" >&2
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Summary
- allow `scripts/build_arm.sh` to run a brief QEMU smoke test via `--test`
- document ARM build and testing options in the README

## Testing
- `bash -n scripts/build_arm.sh`
- `scripts/build_arm.sh --no-clean --test` *(fails: requires long manifest sync, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c5587944c8832fbe310d46b8f13ff2