### PR TITLE
Include L4Re libc headers in bindgen build scripts

### DIFF
--- a/src/l4rust/l4-sys-rust/build.rs
+++ b/src/l4rust/l4-sys-rust/build.rs
@@ -12,6 +12,11 @@ fn main() {
         .blocklist_type("max_align_t")
         .blocklist_file(".*/stdlib.h")
         .ctypes_prefix("core::ffi");
+
+    let libc_include =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../l4re-libc/include");
+    bindings = bindings.clang_arg(format!("-I{}", libc_include.display()));
+
     if let Ok(include_dirs) = ::std::env::var("L4_INCLUDE_DIRS") {
         for item in include_dirs.split(" ") {
             bindings = bindings.clang_arg(item);

--- a/src/l4rust/l4re-rust/build.rs
+++ b/src/l4rust/l4re-rust/build.rs
@@ -7,6 +7,11 @@ fn main() {
         .ctypes_prefix("core::ffi")
         .rustified_enum(".*")
         .header("bindgen.h");
+
+    let libc_include =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../l4re-libc/include");
+    bindings = bindings.clang_arg(format!("-I{}", libc_include.display()));
+
     if let Ok(include_dirs) = ::std::env::var("L4_INCLUDE_DIRS") {
         for item in include_dirs.split(" ") {
             bindings = bindings.clang_arg(item);


### PR DESCRIPTION
## Summary
- add l4re-libc include path to l4-sys-rust build script
- add l4re-libc include path to l4re-rust build script

## Testing
- `cargo build --manifest-path src/l4rust/l4-sys-rust/Cargo.toml` *(fails: failed to get `l4re-libc`)*
- `cargo build --manifest-path src/l4rust/l4re-rust/Cargo.toml` *(fails: failed to get `l4re-libc`)*

------
https://chatgpt.com/codex/tasks/task_e_68c56683c0c4832fbf52caef84c6a2a8