### PR TITLE
Add eventfd support to L4Re libc

### DIFF
--- a/src/l4rust/l4re-libc/Cargo.toml
+++ b/src/l4rust/l4re-libc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "l4re-libc"
 version = "0.1.0"
 edition = "2018"
+build = "build.rs"
 
 [lib]
 name = "l4re_libc"

--- a/src/l4rust/l4re-libc/build.rs
+++ b/src/l4rust/l4re-libc/build.rs
@@ -1,6 +1,7 @@
 fn main() {
-    cc::Build::new()
-        .include("include")
-        .file("src/epoll.c")
-        .compile("l4re_libc_epoll");
+    let mut build = cc::Build::new();
+    build.include("include");
+    build.file("src/epoll.c");
+    build.file("src/eventfd.c");
+    build.compile("l4re_libc_c");
 }

--- a/src/l4rust/l4re-libc/include/sys/eventfd.h
+++ b/src/l4rust/l4re-libc/include/sys/eventfd.h
@@ -1,0 +1,19 @@
+#ifndef _L4RE_LIBC_SYS_EVENTFD_H
+#define _L4RE_LIBC_SYS_EVENTFD_H 1
+
+#include <stdint.h>
+#include <sys/types.h>
+
+typedef uint64_t eventfd_t;
+
+/* Flags for eventfd() */
+#define EFD_SEMAPHORE 1
+#define EFD_CLOEXEC   02000000
+#define EFD_NONBLOCK  00004000
+
+/* Function prototypes */
+int eventfd(unsigned int initval, int flags);
+int eventfd_read(int fd, eventfd_t *value);
+int eventfd_write(int fd, eventfd_t value);
+
+#endif /* _L4RE_LIBC_SYS_EVENTFD_H */

--- a/src/l4rust/l4re-libc/src/eventfd.c
+++ b/src/l4rust/l4re-libc/src/eventfd.c
@@ -1,0 +1,33 @@
+#include "sys/eventfd.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <errno.h>
+
+int eventfd(unsigned int initval, int flags)
+{
+    return (int)syscall(SYS_eventfd2, initval, flags);
+}
+
+int eventfd_read(int fd, eventfd_t *value)
+{
+    ssize_t res = read(fd, value, sizeof(eventfd_t));
+    if (res < 0)
+        return -1;
+    if (res != sizeof(eventfd_t)) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+int eventfd_write(int fd, eventfd_t value)
+{
+    ssize_t res = write(fd, &value, sizeof(eventfd_t));
+    if (res < 0)
+        return -1;
+    if (res != sizeof(eventfd_t)) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}

--- a/src/l4rust/l4re-libc/src/lib.rs
+++ b/src/l4rust/l4re-libc/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use libc::{c_int, c_void, sigset_t};
+use libc::{c_int, c_uint, c_void, sigset_t};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -17,6 +17,12 @@ pub struct epoll_event {
     pub events: u32,
     pub data: epoll_data_t,
 }
+
+pub type eventfd_t = u64;
+
+pub const EFD_SEMAPHORE: c_int = 1;
+pub const EFD_CLOEXEC: c_int = 0o2000000;
+pub const EFD_NONBLOCK: c_int = 0o4000;
 
 pub const EPOLLIN: u32 = 0x001;
 pub const EPOLLPRI: u32 = 0x002;
@@ -39,6 +45,10 @@ pub const EPOLL_CTL_DEL: c_int = 2;
 pub const EPOLL_CTL_MOD: c_int = 3;
 
 extern "C" {
+    pub fn eventfd(initval: c_uint, flags: c_int) -> c_int;
+    pub fn eventfd_read(fd: c_int, value: *mut eventfd_t) -> c_int;
+    pub fn eventfd_write(fd: c_int, value: eventfd_t) -> c_int;
+
     pub fn epoll_create(size: c_int) -> c_int;
     pub fn epoll_create1(flags: c_int) -> c_int;
     pub fn epoll_ctl(epfd: c_int, op: c_int, fd: c_int, event: *mut epoll_event) -> c_int;

--- a/src/l4rust/l4re-libc/tests/eventfd.rs
+++ b/src/l4rust/l4re-libc/tests/eventfd.rs
@@ -1,0 +1,25 @@
+use l4re_libc::*;
+use std::{thread, time::Duration};
+use libc;
+
+#[test]
+fn eventfd_cross_thread() {
+    unsafe {
+        let efd = eventfd(0, 0);
+        assert!(efd >= 0);
+
+        let reader = thread::spawn(move || {
+            let mut val: eventfd_t = 0;
+            assert_eq!(0, eventfd_read(efd, &mut val));
+            val
+        });
+
+        thread::sleep(Duration::from_millis(50));
+        assert_eq!(0, eventfd_write(efd, 1));
+
+        let val = reader.join().unwrap();
+        assert_eq!(val, 1);
+
+        libc::close(efd);
+    }
+}


### PR DESCRIPTION
## Summary
- add eventfd header with flags and prototypes
- implement eventfd and eventfd_read/write using syscalls
- expose eventfd in Rust FFI and build integration
- provide cross-thread eventfd test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c569f11630832fa1a2dc013c94f663