### PR TITLE
Add timerfd support

### DIFF
--- a/src/l4rust/l4re-libc/build.rs
+++ b/src/l4rust/l4re-libc/build.rs
@@ -3,5 +3,6 @@ fn main() {
     build.include("include");
     build.file("src/epoll.c");
     build.file("src/eventfd.c");
+    build.file("src/timerfd.c");
     build.compile("l4re_libc_c");
 }

--- a/src/l4rust/l4re-libc/include/sys/timerfd.h
+++ b/src/l4rust/l4re-libc/include/sys/timerfd.h
@@ -1,0 +1,22 @@
+#ifndef _L4RE_LIBC_SYS_TIMERFD_H
+#define _L4RE_LIBC_SYS_TIMERFD_H 1
+
+#include <time.h>
+#include <sys/types.h>
+
+/* Flags for timerfd_create */
+#define TFD_CLOEXEC   02000000
+#define TFD_NONBLOCK  00004000
+
+/* Flags for timerfd_settime */
+#define TFD_TIMER_ABSTIME       1
+#define TFD_TIMER_CANCEL_ON_SET 2
+
+/* Function prototypes */
+int timerfd_create(int clockid, int flags);
+int timerfd_settime(int fd, int flags,
+                    const struct itimerspec *new_value,
+                    struct itimerspec *old_value);
+int timerfd_gettime(int fd, struct itimerspec *curr_value);
+
+#endif /* _L4RE_LIBC_SYS_TIMERFD_H */

--- a/src/l4rust/l4re-libc/src/lib.rs
+++ b/src/l4rust/l4re-libc/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use libc::{c_int, c_uint, c_void, sigset_t};
+use libc::{c_int, c_uint, c_void, sigset_t, clockid_t, itimerspec};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -23,6 +23,11 @@ pub type eventfd_t = u64;
 pub const EFD_SEMAPHORE: c_int = 1;
 pub const EFD_CLOEXEC: c_int = 0o2000000;
 pub const EFD_NONBLOCK: c_int = 0o4000;
+
+pub const TFD_CLOEXEC: c_int = 0o2000000;
+pub const TFD_NONBLOCK: c_int = 0o4000;
+pub const TFD_TIMER_ABSTIME: c_int = 1;
+pub const TFD_TIMER_CANCEL_ON_SET: c_int = 2;
 
 pub const EPOLLIN: u32 = 0x001;
 pub const EPOLLPRI: u32 = 0x002;
@@ -55,4 +60,9 @@ extern "C" {
     pub fn epoll_wait(epfd: c_int, events: *mut epoll_event, maxevents: c_int, timeout: c_int) -> c_int;
     pub fn epoll_pwait(epfd: c_int, events: *mut epoll_event, maxevents: c_int, timeout: c_int,
         sigmask: *const sigset_t) -> c_int;
+
+    pub fn timerfd_create(clockid: clockid_t, flags: c_int) -> c_int;
+    pub fn timerfd_settime(fd: c_int, flags: c_int, new_value: *const itimerspec,
+        old_value: *mut itimerspec) -> c_int;
+    pub fn timerfd_gettime(fd: c_int, curr_value: *mut itimerspec) -> c_int;
 }

--- a/src/l4rust/l4re-libc/src/timerfd.c
+++ b/src/l4rust/l4re-libc/src/timerfd.c
@@ -1,0 +1,20 @@
+#include "sys/timerfd.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+
+int timerfd_create(int clockid, int flags)
+{
+    return (int)syscall(SYS_timerfd_create, clockid, flags);
+}
+
+int timerfd_settime(int fd, int flags,
+                    const struct itimerspec *new_value,
+                    struct itimerspec *old_value)
+{
+    return (int)syscall(SYS_timerfd_settime, fd, flags, new_value, old_value);
+}
+
+int timerfd_gettime(int fd, struct itimerspec *curr_value)
+{
+    return (int)syscall(SYS_timerfd_gettime, fd, curr_value);
+}

--- a/src/l4rust/l4re-libc/tests/timerfd.rs
+++ b/src/l4rust/l4re-libc/tests/timerfd.rs
@@ -1,0 +1,38 @@
+use l4re_libc::*;
+use libc::{self, c_void, itimerspec, timespec};
+
+#[test]
+fn timerfd_epoll_ready() {
+    unsafe {
+        let tfd = timerfd_create(libc::CLOCK_MONOTONIC, 0);
+        assert!(tfd >= 0);
+
+        let new_value = itimerspec {
+            it_interval: timespec { tv_sec: 0, tv_nsec: 0 },
+            it_value: timespec { tv_sec: 0, tv_nsec: 100_000_000 },
+        };
+        assert_eq!(0, timerfd_settime(tfd, 0, &new_value, std::ptr::null_mut()));
+
+        let epfd = epoll_create1(0);
+        assert!(epfd >= 0);
+
+        let mut ev = epoll_event {
+            events: EPOLLIN,
+            data: epoll_data_t { fd: tfd },
+        };
+        assert_eq!(0, epoll_ctl(epfd, EPOLL_CTL_ADD, tfd, &mut ev));
+
+        let mut events = [epoll_event { events: 0, data: epoll_data_t { u64: 0 } }];
+        let n = epoll_wait(epfd, events.as_mut_ptr(), 1, 500);
+        assert_eq!(1, n);
+        assert!(events[0].events & EPOLLIN != 0);
+
+        let mut expirations: u64 = 0;
+        let ptr = &mut expirations as *mut u64 as *mut c_void;
+        assert_eq!(8, libc::read(tfd, ptr, 8));
+        assert_eq!(1, expirations);
+
+        libc::close(tfd);
+        libc::close(epfd);
+    }
+}


### PR DESCRIPTION
## Summary
- add timerfd header with flags and prototypes
- implement timerfd syscalls and expose in Rust FFI
- test timerfd readiness through epoll

## Testing
- `cd src/l4rust/l4re-libc && cargo test`
