### PR TITLE
Add signalfd support to l4re-libc

### DIFF
--- a/src/l4rust/l4re-libc/build.rs
+++ b/src/l4rust/l4re-libc/build.rs
@@ -3,6 +3,7 @@ fn main() {
     build.include("include");
     build.file("src/epoll.c");
     build.file("src/eventfd.c");
+    build.file("src/signalfd.c");
     build.file("src/timerfd.c");
     build.compile("l4re_libc_c");
 }

--- a/src/l4rust/l4re-libc/include/sys/signalfd.h
+++ b/src/l4rust/l4re-libc/include/sys/signalfd.h
@@ -1,0 +1,42 @@
+#ifndef _L4RE_LIBC_SYS_SIGNALFD_H
+#define _L4RE_LIBC_SYS_SIGNALFD_H 1
+
+#include <stdint.h>
+#include <signal.h>
+#include <sys/types.h>
+
+/* Structure returned by read() on a signalfd */
+struct signalfd_siginfo {
+    uint32_t ssi_signo;
+    int32_t  ssi_errno;
+    int32_t  ssi_code;
+    uint32_t ssi_pid;
+    uint32_t ssi_uid;
+    int32_t  ssi_fd;
+    uint32_t ssi_tid;
+    uint32_t ssi_band;
+    uint32_t ssi_overrun;
+    uint32_t ssi_trapno;
+    int32_t  ssi_status;
+    int32_t  ssi_int;
+    uint64_t ssi_ptr;
+    uint64_t ssi_utime;
+    uint64_t ssi_stime;
+    uint64_t ssi_addr;
+    uint16_t ssi_addr_lsb;
+    uint16_t __pad2;
+    int32_t  ssi_syscall;
+    uint64_t ssi_call_addr;
+    uint32_t ssi_arch;
+    uint8_t  __pad[28];
+};
+
+/* Flags for signalfd */
+#define SFD_CLOEXEC  02000000
+#define SFD_NONBLOCK 00004000
+
+/* Function prototypes */
+int signalfd(int fd, const sigset_t *mask, int flags);
+int signalfd4(int fd, const sigset_t *mask, size_t size, int flags);
+
+#endif /* _L4RE_LIBC_SYS_SIGNALFD_H */

--- a/src/l4rust/l4re-libc/src/lib.rs
+++ b/src/l4rust/l4re-libc/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use libc::{c_int, c_uint, c_void, sigset_t, clockid_t, itimerspec};
+use libc::{c_int, c_uint, c_void, sigset_t, clockid_t, itimerspec, size_t};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -29,6 +29,9 @@ pub const TFD_NONBLOCK: c_int = 0o4000;
 pub const TFD_TIMER_ABSTIME: c_int = 1;
 pub const TFD_TIMER_CANCEL_ON_SET: c_int = 2;
 
+pub const SFD_CLOEXEC: c_int = 0o2000000;
+pub const SFD_NONBLOCK: c_int = 0o4000;
+
 pub const EPOLLIN: u32 = 0x001;
 pub const EPOLLPRI: u32 = 0x002;
 pub const EPOLLOUT: u32 = 0x004;
@@ -49,6 +52,33 @@ pub const EPOLL_CTL_ADD: c_int = 1;
 pub const EPOLL_CTL_DEL: c_int = 2;
 pub const EPOLL_CTL_MOD: c_int = 3;
 
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct signalfd_siginfo {
+    pub ssi_signo: u32,
+    pub ssi_errno: i32,
+    pub ssi_code: i32,
+    pub ssi_pid: u32,
+    pub ssi_uid: u32,
+    pub ssi_fd: i32,
+    pub ssi_tid: u32,
+    pub ssi_band: u32,
+    pub ssi_overrun: u32,
+    pub ssi_trapno: u32,
+    pub ssi_status: i32,
+    pub ssi_int: i32,
+    pub ssi_ptr: u64,
+    pub ssi_utime: u64,
+    pub ssi_stime: u64,
+    pub ssi_addr: u64,
+    pub ssi_addr_lsb: u16,
+    pub __pad2: u16,
+    pub ssi_syscall: i32,
+    pub ssi_call_addr: u64,
+    pub ssi_arch: u32,
+    pub __pad: [u8; 28],
+}
+
 extern "C" {
     pub fn eventfd(initval: c_uint, flags: c_int) -> c_int;
     pub fn eventfd_read(fd: c_int, value: *mut eventfd_t) -> c_int;
@@ -64,5 +94,8 @@ extern "C" {
     pub fn timerfd_create(clockid: clockid_t, flags: c_int) -> c_int;
     pub fn timerfd_settime(fd: c_int, flags: c_int, new_value: *const itimerspec,
         old_value: *mut itimerspec) -> c_int;
-    pub fn timerfd_gettime(fd: c_int, curr_value: *mut itimerspec) -> c_int;
-}
+      pub fn timerfd_gettime(fd: c_int, curr_value: *mut itimerspec) -> c_int;
+
+      pub fn signalfd(fd: c_int, mask: *const sigset_t, flags: c_int) -> c_int;
+      pub fn signalfd4(fd: c_int, mask: *const sigset_t, size: size_t, flags: c_int) -> c_int;
+  }

--- a/src/l4rust/l4re-libc/src/signalfd.c
+++ b/src/l4rust/l4re-libc/src/signalfd.c
@@ -1,0 +1,13 @@
+#include "sys/signalfd.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+
+int signalfd(int fd, const sigset_t *mask, int flags)
+{
+    return signalfd4(fd, mask, sizeof(uint64_t), flags);
+}
+
+int signalfd4(int fd, const sigset_t *mask, size_t size, int flags)
+{
+    return (int)syscall(SYS_signalfd4, fd, mask, size, flags);
+}

--- a/src/l4rust/l4re-libc/tests/signalfd.rs
+++ b/src/l4rust/l4re-libc/tests/signalfd.rs
@@ -1,0 +1,32 @@
+use l4re_libc::*;
+use libc;
+use std::{mem, ptr};
+
+#[test]
+fn signalfd_sigusr1() {
+    unsafe {
+        // block SIGUSR1 so it can be received via signalfd
+        let mut mask: libc::sigset_t = mem::zeroed();
+        libc::sigemptyset(&mut mask);
+        libc::sigaddset(&mut mask, libc::SIGUSR1);
+        assert_eq!(0, libc::sigprocmask(libc::SIG_BLOCK, &mask, ptr::null_mut()));
+
+        // create signalfd to receive SIGUSR1
+        let fd = signalfd(-1, &mask, 0);
+        assert!(fd >= 0);
+
+        // send SIGUSR1 to the current thread
+        assert_eq!(0, libc::raise(libc::SIGUSR1));
+
+        let mut info: signalfd_siginfo = mem::zeroed();
+        let res = libc::read(
+            fd,
+            &mut info as *mut _ as *mut libc::c_void,
+            mem::size_of::<signalfd_siginfo>() as libc::size_t,
+        );
+        assert_eq!(res as usize, mem::size_of::<signalfd_siginfo>());
+        assert_eq!(info.ssi_signo, libc::SIGUSR1 as u32);
+
+        libc::close(fd);
+    }
+}


### PR DESCRIPTION
## Summary
- add `signalfd` API and flags
- expose `signalfd_siginfo` and FFI bindings
- regression test for SIGUSR1 via signalfd

## Testing
- `cd src/l4rust/l4re-libc && cargo test --quiet`
