### PR TITLE
Add inotify bindings and test

### DIFF
--- a/src/l4rust/l4re-libc/build.rs
+++ b/src/l4rust/l4re-libc/build.rs
@@ -5,5 +5,6 @@ fn main() {
     build.file("src/eventfd.c");
     build.file("src/signalfd.c");
     build.file("src/timerfd.c");
+    build.file("src/inotify.c");
     build.compile("l4re_libc_c");
 }

--- a/src/l4rust/l4re-libc/include/sys/inotify.h
+++ b/src/l4rust/l4re-libc/include/sys/inotify.h
@@ -1,0 +1,49 @@
+#ifndef _L4RE_LIBC_SYS_INOTIFY_H
+#define _L4RE_LIBC_SYS_INOTIFY_H 1
+
+#include <stdint.h>
+#include <sys/types.h>
+
+struct inotify_event {
+    int      wd;
+    uint32_t mask;
+    uint32_t cookie;
+    uint32_t len;
+    char     name[];
+};
+
+#define IN_ACCESS        0x00000001
+#define IN_MODIFY        0x00000002
+#define IN_ATTRIB        0x00000004
+#define IN_CLOSE_WRITE   0x00000008
+#define IN_CLOSE_NOWRITE 0x00000010
+#define IN_OPEN          0x00000020
+#define IN_MOVED_FROM    0x00000040
+#define IN_MOVED_TO      0x00000080
+#define IN_CREATE        0x00000100
+#define IN_DELETE        0x00000200
+#define IN_DELETE_SELF   0x00000400
+#define IN_MOVE_SELF     0x00000800
+#define IN_UNMOUNT       0x00002000
+#define IN_Q_OVERFLOW    0x00004000
+#define IN_IGNORED       0x00008000
+
+#define IN_ONLYDIR       0x01000000
+#define IN_DONT_FOLLOW   0x02000000
+#define IN_EXCL_UNLINK   0x04000000
+#define IN_MASK_ADD      0x20000000
+#define IN_ISDIR         0x40000000
+#define IN_ONESHOT       0x80000000
+
+#define IN_ALL_EVENTS (IN_ACCESS | IN_MODIFY | IN_ATTRIB | IN_CLOSE_WRITE | \
+                       IN_CLOSE_NOWRITE | IN_OPEN | IN_MOVED_FROM | IN_MOVED_TO | \
+                       IN_CREATE | IN_DELETE | IN_DELETE_SELF | IN_MOVE_SELF)
+
+#define IN_CLOEXEC   02000000
+#define IN_NONBLOCK  00004000
+
+int inotify_init1(int flags);
+int inotify_add_watch(int fd, const char *pathname, uint32_t mask);
+int inotify_rm_watch(int fd, int wd);
+
+#endif /* _L4RE_LIBC_SYS_INOTIFY_H */

--- a/src/l4rust/l4re-libc/src/inotify.c
+++ b/src/l4rust/l4re-libc/src/inotify.c
@@ -1,0 +1,23 @@
+#include "sys/inotify.h"
+#include <sys/syscall.h>
+#include <unistd.h>
+
+int inotify_init(void)
+{
+    return inotify_init1(0);
+}
+
+int inotify_init1(int flags)
+{
+    return (int)syscall(SYS_inotify_init1, flags);
+}
+
+int inotify_add_watch(int fd, const char *pathname, uint32_t mask)
+{
+    return (int)syscall(SYS_inotify_add_watch, fd, pathname, mask);
+}
+
+int inotify_rm_watch(int fd, int wd)
+{
+    return (int)syscall(SYS_inotify_rm_watch, fd, wd);
+}

--- a/src/l4rust/l4re-libc/src/lib.rs
+++ b/src/l4rust/l4re-libc/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use libc::{c_int, c_uint, c_void, sigset_t, clockid_t, itimerspec, size_t};
+use libc::{c_char, c_int, c_uint, c_void, sigset_t, clockid_t, itimerspec, size_t};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -31,6 +31,34 @@ pub const TFD_TIMER_CANCEL_ON_SET: c_int = 2;
 
 pub const SFD_CLOEXEC: c_int = 0o2000000;
 pub const SFD_NONBLOCK: c_int = 0o4000;
+
+pub const IN_CLOEXEC: c_int = 0o2000000;
+pub const IN_NONBLOCK: c_int = 0o4000;
+
+pub const IN_ACCESS: u32 = 0x00000001;
+pub const IN_MODIFY: u32 = 0x00000002;
+pub const IN_ATTRIB: u32 = 0x00000004;
+pub const IN_CLOSE_WRITE: u32 = 0x00000008;
+pub const IN_CLOSE_NOWRITE: u32 = 0x00000010;
+pub const IN_OPEN: u32 = 0x00000020;
+pub const IN_MOVED_FROM: u32 = 0x00000040;
+pub const IN_MOVED_TO: u32 = 0x00000080;
+pub const IN_CREATE: u32 = 0x00000100;
+pub const IN_DELETE: u32 = 0x00000200;
+pub const IN_DELETE_SELF: u32 = 0x00000400;
+pub const IN_MOVE_SELF: u32 = 0x00000800;
+pub const IN_UNMOUNT: u32 = 0x00002000;
+pub const IN_Q_OVERFLOW: u32 = 0x00004000;
+pub const IN_IGNORED: u32 = 0x00008000;
+pub const IN_ONLYDIR: u32 = 0x01000000;
+pub const IN_DONT_FOLLOW: u32 = 0x02000000;
+pub const IN_EXCL_UNLINK: u32 = 0x04000000;
+pub const IN_MASK_ADD: u32 = 0x20000000;
+pub const IN_ISDIR: u32 = 0x40000000;
+pub const IN_ONESHOT: u32 = 0x80000000;
+pub const IN_ALL_EVENTS: u32 = IN_ACCESS | IN_MODIFY | IN_ATTRIB | IN_CLOSE_WRITE |
+    IN_CLOSE_NOWRITE | IN_OPEN | IN_MOVED_FROM | IN_MOVED_TO | IN_CREATE | IN_DELETE |
+    IN_DELETE_SELF | IN_MOVE_SELF;
 
 pub const EPOLLIN: u32 = 0x001;
 pub const EPOLLPRI: u32 = 0x002;
@@ -79,6 +107,16 @@ pub struct signalfd_siginfo {
     pub __pad: [u8; 28],
 }
 
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct inotify_event {
+    pub wd: c_int,
+    pub mask: u32,
+    pub cookie: u32,
+    pub len: u32,
+    pub name: [c_char; 0],
+}
+
 extern "C" {
     pub fn eventfd(initval: c_uint, flags: c_int) -> c_int;
     pub fn eventfd_read(fd: c_int, value: *mut eventfd_t) -> c_int;
@@ -98,4 +136,8 @@ extern "C" {
 
       pub fn signalfd(fd: c_int, mask: *const sigset_t, flags: c_int) -> c_int;
       pub fn signalfd4(fd: c_int, mask: *const sigset_t, size: size_t, flags: c_int) -> c_int;
+
+      pub fn inotify_init1(flags: c_int) -> c_int;
+      pub fn inotify_add_watch(fd: c_int, pathname: *const c_char, mask: u32) -> c_int;
+      pub fn inotify_rm_watch(fd: c_int, wd: c_int) -> c_int;
   }

--- a/src/l4rust/l4re-libc/tests/inotify.rs
+++ b/src/l4rust/l4re-libc/tests/inotify.rs
@@ -1,0 +1,40 @@
+use l4re_libc::*;
+use libc::{c_void};
+use std::ffi::CString;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::os::unix::ffi::OsStrExt;
+
+#[test]
+fn inotify_modify_event() {
+    unsafe {
+        let dir = std::env::temp_dir();
+        let path = dir.join("inotify_test_file");
+
+        {
+            let mut f = File::create(&path).unwrap();
+            f.write_all(b"initial").unwrap();
+        }
+
+        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+        let fd = inotify_init1(0);
+        assert!(fd >= 0);
+        let wd = inotify_add_watch(fd, c_path.as_ptr(), IN_MODIFY);
+        assert!(wd >= 0);
+
+        {
+            let mut f = OpenOptions::new().write(true).open(&path).unwrap();
+            f.write_all(b"update").unwrap();
+            f.flush().unwrap();
+        }
+
+        let mut buf = [0u8; 1024];
+        let n = libc::read(fd, buf.as_mut_ptr() as *mut c_void, buf.len());
+        assert!(n as usize >= std::mem::size_of::<inotify_event>());
+        let event = &*(buf.as_ptr() as *const inotify_event);
+        assert!(event.mask & IN_MODIFY != 0);
+
+        libc::close(fd);
+        std::fs::remove_file(&path).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- add `inotify.h` with constants and prototypes
- implement `inotify` syscall wrappers and expose them in Rust
- test basic file modification notification

## Testing
- `cd src/l4rust/l4re-libc && cargo test`
