### PR TITLE
Package fs_server and include in boot image

### DIFF
--- a/files/cfg/bash.cfg
+++ b/files/cfg/bash.cfg
@@ -1,0 +1,9 @@
+local L4 = require("L4")
+local ld = L4.default_loader
+
+-- start the file system server
+ld:start({log = {"fs_server", "green"}}, "rom/fs_server")
+
+-- launch bash afterwards
+ld:start({log = {"bash", "yellow"}}, "rom/bash")
+

--- a/src/pkg/fs_server/Makefile
+++ b/src/pkg/fs_server/Makefile
@@ -1,0 +1,9 @@
+PKGDIR ?= .
+L4DIR ?= $(PKGDIR)/../..
+
+TARGET := fs_server
+
+install:: $(TARGET)
+	$(INSTALL) -m 755 $(TARGET) $(INSTDIR)/boot/
+
+include $(L4DIR)/mk/subdir.mk


### PR DESCRIPTION
## Summary
- package fs_server so its binary installs under boot
- ensure bash startup config launches fs_server before bash

## Testing
- `scripts/build_arm.sh --no-clean` *(fails: could not find Cargo.toml in src/l4rust)*