### PR TITLE
Implement virtio-net queue and frame handling

### DIFF
--- a/src/net_server/src/main.rs
+++ b/src/net_server/src/main.rs
@@ -50,14 +50,17 @@ unsafe fn run() {
             // Operation 0: send a packet. For demonstration we simply
             // acknowledge the request.
             0 => {
-                let _ = net.send(&[]);
+                let _ = net.send_frame(&[]);
                 (*l4::l4_utcb_mr()).mr[0] = 0;
             }
             // Operation 1: receive a packet. We currently signal that no
             // data is available.
             1 => {
                 let mut buf = [0u8; 0];
-                let res = net.recv(&mut buf).map(|len| len as u64).unwrap_or(u64::MAX);
+                let res = net
+                    .receive_frame(&mut buf)
+                    .map(|len| len as u64)
+                    .unwrap_or(u64::MAX);
                 (*l4::l4_utcb_mr()).mr[0] = res;
             }
             // Unsupported operations are indicated with all bits set.

--- a/src/net_server/src/virtio.rs
+++ b/src/net_server/src/virtio.rs
@@ -1,13 +1,88 @@
 use l4re::sys::l4re_env_get_cap;
-use l4_sys::l4_cap_idx_t;
+use l4_sys::{l4_cap_idx_t, l4_utcb};
 
-/// Minimal skeleton for a virtio-net driver. The implementation only
-/// fetches device capabilities from the L4Re environment and provides
-/// stub send/receive methods. A real driver would manage descriptor
-/// rings and interact with the device via MMIO.
+// Constants for a very small virtqueue. Real devices often support much
+// larger queues. Eight entries suffice for demonstration purposes and keep
+// memory usage minimal.
+const QUEUE_SIZE: usize = 8;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct VirtqDesc {
+    addr: u64,
+    len: u32,
+    flags: u16,
+    next: u16,
+}
+
+#[repr(C)]
+struct VirtqAvail {
+    flags: u16,
+    idx: u16,
+    ring: [u16; QUEUE_SIZE],
+    used_event: u16,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct VirtqUsedElem {
+    id: u32,
+    len: u32,
+}
+
+#[repr(C)]
+struct VirtqUsed {
+    flags: u16,
+    idx: u16,
+    ring: [VirtqUsedElem; QUEUE_SIZE],
+    avail_event: u16,
+}
+
+// Simple virtqueue descriptor set.
+struct VirtQueue {
+    desc: [VirtqDesc; QUEUE_SIZE],
+    avail: VirtqAvail,
+    used: VirtqUsed,
+}
+
+impl VirtQueue {
+    const fn new() -> Self {
+        const DESC: VirtqDesc = VirtqDesc { addr: 0, len: 0, flags: 0, next: 0 };
+        const USED_ELEM: VirtqUsedElem = VirtqUsedElem { id: 0, len: 0 };
+        Self {
+            desc: [DESC; QUEUE_SIZE],
+            avail: VirtqAvail { flags: 0, idx: 0, ring: [0; QUEUE_SIZE], used_event: 0 },
+            used: VirtqUsed {
+                flags: 0,
+                idx: 0,
+                ring: [USED_ELEM; QUEUE_SIZE],
+                avail_event: 0,
+            },
+        }
+    }
+}
+
+// Network header as defined by the virtio-net specification without any
+// offloading features enabled.
+#[repr(C, packed)]
+#[derive(Copy, Clone, Default)]
+struct VirtioNetHdr {
+    flags: u8,
+    gso_type: u8,
+    hdr_len: u16,
+    gso_size: u16,
+    csum_start: u16,
+    csum_offset: u16,
+}
+
+/// Minimal virtio-net driver. The implementation models the data structures
+/// required to submit and receive Ethernet frames. It intentionally omits
+/// error handling and device negotiation which would be required for a
+/// production ready driver.
 pub struct VirtioNet {
     device: l4_cap_idx_t,
     irq: l4_cap_idx_t,
+    queue: VirtQueue,
 }
 
 impl VirtioNet {
@@ -17,19 +92,80 @@ impl VirtioNet {
     pub unsafe fn new() -> Option<Self> {
         let device = l4re_env_get_cap("virtio_net")?;
         let irq = l4re_env_get_cap("virtio_net_irq")?;
-        Some(Self { device, irq })
+        Some(Self { device, irq, queue: VirtQueue::new() })
     }
 
-    /// Send a packet to the network device. Currently this is a stub that
-    /// simply pretends success.
-    pub fn send(&mut self, _data: &[u8]) -> Result<(), ()> {
+    /// Enqueue an Ethernet frame for transmission.
+    pub fn send_frame(&mut self, frame: &[u8]) -> Result<(), ()> {
+        let header = VirtioNetHdr::default();
+
+        // Descriptor 0: header
+        self.queue.desc[0] = VirtqDesc {
+            addr: &header as *const _ as u64,
+            len: core::mem::size_of::<VirtioNetHdr>() as u32,
+            flags: 0x0002, // next
+            next: 1,
+        };
+
+        // Descriptor 1: frame data
+        self.queue.desc[1] = VirtqDesc {
+            addr: frame.as_ptr() as u64,
+            len: frame.len() as u32,
+            flags: 0,
+            next: 0,
+        };
+
+        // Place descriptor chain into available ring
+        let idx = self.queue.avail.idx as usize % QUEUE_SIZE;
+        self.queue.avail.ring[idx] = 0;
+        self.queue.avail.idx = self.queue.avail.idx.wrapping_add(1);
+
+        // Wait for completion signalled by an interrupt
+        let mut label = 0u64;
+        let _ = unsafe { l4::l4_ipc_receive(self.irq, l4_utcb(), l4::l4_timeout_t { raw: 0 }) };
+        let _ = unsafe { l4::l4_ipc_wait(l4_utcb(), &mut label, l4::l4_timeout_t { raw: 0 }) };
+
         Ok(())
     }
 
-    /// Receive a packet into the provided buffer. Returns the number of
-    /// bytes received on success. This stub always indicates that no data
-    /// was received.
-    pub fn recv(&mut self, _buf: &mut [u8]) -> Result<usize, ()> {
-        Err(())
+    /// Dequeue an Ethernet frame into the provided buffer. Returns the number
+    /// of bytes copied into `buf`.
+    pub fn receive_frame(&mut self, buf: &mut [u8]) -> Result<usize, ()> {
+        let mut header = VirtioNetHdr::default();
+
+        // Descriptor 0: header written by device
+        self.queue.desc[0] = VirtqDesc {
+            addr: &mut header as *mut _ as u64,
+            len: core::mem::size_of::<VirtioNetHdr>() as u32,
+            flags: 0x0003, // device writes | next
+            next: 1,
+        };
+
+        // Descriptor 1: frame buffer written by device
+        self.queue.desc[1] = VirtqDesc {
+            addr: buf.as_mut_ptr() as u64,
+            len: buf.len() as u32,
+            flags: 0x0001, // device writes
+            next: 0,
+        };
+
+        // Make descriptor available
+        let idx = self.queue.avail.idx as usize % QUEUE_SIZE;
+        self.queue.avail.ring[idx] = 0;
+        self.queue.avail.idx = self.queue.avail.idx.wrapping_add(1);
+
+        // Wait for interrupt
+        let mut label = 0u64;
+        let _ = unsafe { l4::l4_ipc_receive(self.irq, l4_utcb(), l4::l4_timeout_t { raw: 0 }) };
+        let _ = unsafe { l4::l4_ipc_wait(l4_utcb(), &mut label, l4::l4_timeout_t { raw: 0 }) };
+
+        // Determine length from used ring
+        let used_idx = self.queue.used.idx.wrapping_sub(1) as usize % QUEUE_SIZE;
+        let len = self.queue.used.ring[used_idx].len as usize;
+        if len < core::mem::size_of::<VirtioNetHdr>() {
+            return Err(());
+        }
+        Ok(len - core::mem::size_of::<VirtioNetHdr>())
     }
 }
+


### PR DESCRIPTION
## Summary
- Model virtio-net descriptor queues and headers
- Add `send_frame` and `receive_frame` methods using the virtqueue
- Hook network server IPC loop to call the new driver APIs

## Testing
- `cargo check` *(fails: 'l4/re/c/dataspace.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c57af51368832f8d8584668036103d