### PR TITLE
Add network client crate and protocol layout

### DIFF
--- a/src/l4rust/Makefile
+++ b/src/l4rust/Makefile
@@ -1,7 +1,7 @@
 PKGDIR	= .
 L4DIR	?= $(PKGDIR)/../..
 
-TARGET = l4re-rust l4-rust l4-sys-rust libl4re-wrapper
+TARGET = l4re-rust l4-rust l4-sys-rust libl4re-wrapper net-client
 
 l4-sys-rust: libl4re-wrapper
 l4-rust: l4-sys-rust

--- a/src/l4rust/net-client/Cargo.toml
+++ b/src/l4rust/net-client/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "net_client"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+l4re = { path = "../l4re-rust" }
+l4 = { path = "../l4-rust" }

--- a/src/l4rust/net-client/README.md
+++ b/src/l4rust/net-client/README.md
@@ -1,0 +1,21 @@
+# net-client
+
+Minimal client-side helpers for the `global_net` network service.  The
+`NetClient` type obtains the IPC gate capability from the L4Re
+environment and provides tiny wrappers around the message register
+protocol.
+
+## Example
+
+```rust
+use net_client::NetClient;
+
+let net = NetClient::new().expect("network service not available");
+let sock = net.open_socket().expect("open failed");
+net.send(sock, 0xdead_beef).expect("send failed");
+let word = net.recv(sock).expect("recv failed");
+net.close(sock).expect("close failed");
+```
+
+The message format is intentionally small and is expected to evolve as
+the network server grows more features.

--- a/src/l4rust/net-client/src/lib.rs
+++ b/src/l4rust/net-client/src/lib.rs
@@ -1,0 +1,140 @@
+#![no_std]
+
+//! Simple client library for the `global_net` network service.
+//!
+//! # Message register layout
+//!
+//! All operations use the first message register (`MR0`) to denote the
+//! operation code. Additional registers carry operation specific
+//! arguments as documented below:
+//!
+//! ```text
+//! MR0: operation code
+//!
+//! Socket open (OP_OPEN)
+//!   MR1: protocol (0 = UDP)
+//!   Reply: MR0 = socket handle
+//!
+//! Socket send (OP_SEND)
+//!   MR1: socket handle
+//!   MR2: length in bytes
+//!   MR3..: payload (truncated to available registers)
+//!   Reply: MR0 = status (0 = ok)
+//!
+//! Socket receive (OP_RECV)
+//!   MR1: socket handle
+//!   MR2: buffer capacity
+//!   Reply: MR0 = bytes received
+//!   MR1..: payload
+//!
+//! Socket close (OP_CLOSE)
+//!   MR1: socket handle
+//!   Reply: MR0 = status (0 = ok)
+//! ```
+//!
+//! The functions provided here implement these operations for small
+//! messages entirely transmitted via the message registers. They are
+//! intended as a starting point for more fully fledged networking
+//! support.
+
+use l4re::sys::l4re_env_get_cap;
+use l4::sys::{l4_ipc_call, l4_ipc_error, l4_msgtag, l4_utcb};
+
+/// Operation code: open a socket.
+pub const OP_OPEN: u64 = 0;
+/// Operation code: send data.
+pub const OP_SEND: u64 = 1;
+/// Operation code: receive data.
+pub const OP_RECV: u64 = 2;
+/// Operation code: close a socket.
+pub const OP_CLOSE: u64 = 3;
+
+/// Client handle to the network service.
+pub struct NetClient {
+    gate: l4re::sys::l4_cap_idx_t,
+}
+
+impl NetClient {
+    /// Retrieve the `global_net` capability from the environment.
+    pub fn new() -> Option<Self> {
+        l4re_env_get_cap("global_net").map(|gate| NetClient { gate })
+    }
+
+    /// Request a UDP socket from the server.
+    pub fn open_socket(&self) -> Result<u64, i32> {
+        unsafe {
+            (*l4::sys::l4_utcb_mr()).mr[0] = OP_OPEN;
+            (*l4::sys::l4_utcb_mr()).mr[1] = 0; // protocol: UDP
+            let tag = l4_ipc_call(
+                self.gate,
+                l4_utcb(),
+                l4_msgtag(0, 2, 0, 0),
+                l4::sys::l4_timeout_t { raw: 0 },
+            );
+            let err = l4_ipc_error(tag, l4_utcb());
+            if err != 0 {
+                return Err(err);
+            }
+            Ok((*l4::sys::l4_utcb_mr()).mr[0])
+        }
+    }
+
+    /// Send a single word of data to the server.
+    pub fn send(&self, handle: u64, word: u64) -> Result<(), i32> {
+        unsafe {
+            (*l4::sys::l4_utcb_mr()).mr[0] = OP_SEND;
+            (*l4::sys::l4_utcb_mr()).mr[1] = handle;
+            (*l4::sys::l4_utcb_mr()).mr[2] = word;
+            let tag = l4_ipc_call(
+                self.gate,
+                l4_utcb(),
+                l4_msgtag(0, 3, 0, 0),
+                l4::sys::l4_timeout_t { raw: 0 },
+            );
+            let err = l4_ipc_error(tag, l4_utcb());
+            if err != 0 {
+                return Err(err);
+            }
+            Ok(())
+        }
+    }
+
+    /// Receive a single word of data from the server.
+    pub fn recv(&self, handle: u64) -> Result<u64, i32> {
+        unsafe {
+            (*l4::sys::l4_utcb_mr()).mr[0] = OP_RECV;
+            (*l4::sys::l4_utcb_mr()).mr[1] = handle;
+            let tag = l4_ipc_call(
+                self.gate,
+                l4_utcb(),
+                l4_msgtag(0, 2, 0, 0),
+                l4::sys::l4_timeout_t { raw: 0 },
+            );
+            let err = l4_ipc_error(tag, l4_utcb());
+            if err != 0 {
+                return Err(err);
+            }
+            Ok((*l4::sys::l4_utcb_mr()).mr[0])
+        }
+    }
+
+    /// Close the socket.
+    pub fn close(&self, handle: u64) -> Result<(), i32> {
+        unsafe {
+            (*l4::sys::l4_utcb_mr()).mr[0] = OP_CLOSE;
+            (*l4::sys::l4_utcb_mr()).mr[1] = handle;
+            let tag = l4_ipc_call(
+                self.gate,
+                l4_utcb(),
+                l4_msgtag(0, 2, 0, 0),
+                l4::sys::l4_timeout_t { raw: 0 },
+            );
+            let err = l4_ipc_error(tag, l4_utcb());
+            if err != 0 {
+                return Err(err);
+            }
+            Ok(())
+        }
+    }
+}
+

--- a/src/net_server/src/proto.rs
+++ b/src/net_server/src/proto.rs
@@ -1,0 +1,23 @@
+//! Message register layout for the simple network protocol.
+//!
+//! The network service communicates via L4 IPC message registers as
+//! follows:
+//!
+//! ```text
+//! MR0: operation
+//!     0 = open
+//!     1 = send
+//!     2 = recv
+//!     3 = close
+//! MR1: socket handle (except for open)
+//! MR2: length / buffer size (send/recv)
+//! MR3..: payload data
+//! ```
+//!
+//! Replies reuse the same layout with `MR0` carrying either a new socket
+//! handle (for open) or a status/length field for other operations.
+
+pub const OP_OPEN: u64 = 0;
+pub const OP_SEND: u64 = 1;
+pub const OP_RECV: u64 = 2;
+pub const OP_CLOSE: u64 = 3;


### PR DESCRIPTION
## Summary
- document message register layout for network operations
- implement a minimal `net_client` crate using the `global_net` capability
- add usage example and integrate the crate into the build

## Testing
- `cargo check --manifest-path src/l4rust/net-client/Cargo.toml` *(fails: 'l4/re/c/dataspace.h' file not found)*

