### PR TITLE
Build net server example and expose global IPC gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,18 @@ bash-image: $(addprefix obj/bash/,$(addsuffix /bash,$(BASH_ARCHES))) build_image
 obj/bash/%/bash:
 	@scripts/build_arm.sh --no-clean
 
+EXAMPLE_CRATES := \
+src/ipc-example/client \
+src/ipc-example/server \
+src/fs_server \
+src/net_server
+
+examples:
+	@for crate in $(EXAMPLE_CRATES); do \
+		echo "Building $$crate"; \
+		cargo build --manifest-path $$crate/Cargo.toml --release; \
+	done
+
 gen_prebuilt: copy_prebuilt pre-built-images/l4image
 
 copy_prebuilt2:
@@ -149,6 +161,8 @@ help:
 	@echo "  setup"
 	@echo "  gen_prebuilt"
 	@echo "  bash-image    Build image with Bash as first program"
+	@echo "  examples      Build Rust example servers and clients"
 
 .PHONY: setup all build_all clean help \
-	build_images build_fiasco build_l4re build_l4linux bash-image
+build_images build_fiasco build_l4re build_l4linux bash-image \
+examples

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ cd src/ &&
 cd .. &&
 make setup &&
 make &&
+# Build example Rust crates including the network server
+make examples &&
 mkdir lib &&
 cd lib/ &&
 find ../obj/ -type f | grep "\.rlib" | xargs -i cp {} . 

--- a/files/cfg/bash.cfg
+++ b/files/cfg/bash.cfg
@@ -4,6 +4,9 @@ local ld = L4.default_loader
 -- allocate a communication channel for the filesystem server
 local fs_chan = ld:new_channel()
 
+-- allocate a communication channel for the network server
+local net_chan = ld:new_channel()
+
 -- start the file system server with the required capabilities so it can
 -- access the virtio block device and publish its IPC gate as "global_fs"
 ld:start({
@@ -20,10 +23,25 @@ ld:start({
   }
 }, "rom/fs_server")
 
+-- start the network server and publish its IPC gate as "global_net"
+ld:start({
+  log = {"net_server", "blue"},
+  caps = {
+    -- server side of the global network gate
+    global_net = net_chan:svr(),
+    -- grant access to the virtio network device and its interrupt
+    virtio_net = L4.Env.virtio_net,
+    virtio_net_irq = L4.Env.virtio_net_irq,
+    -- allow mapping of IO memory and scheduling
+    iomem = L4.Env.sigma0,
+    scheduler = L4.Env.sched,
+  }
+}, "rom/net_server")
+
 -- launch bash afterwards. The client side of the global_fs channel is passed
--- so programs can look it up from their environment and talk to the server.
+-- so programs can look it up from their environment and talk to the servers.
 ld:start({
   log = {"bash", "yellow"},
-  caps = { global_fs = fs_chan }
+  caps = { global_fs = fs_chan, global_net = net_chan }
 }, "rom/bash")
 


### PR DESCRIPTION
## Summary
- compile example Rust crates, including new `net_server`
- add `net_server` start-up configuration and register `global_net` gate

## Testing
- `cargo build --manifest-path src/net_server/Cargo.toml --quiet` *(fails: `bindgen.h:1:10: fatal error: 'l4/re/c/dataspace.h' file not found`)*
- `make examples` *(fails: `bindgen.h:2:10: fatal error: 'l4/sys/consts.h' file not found`)*
