### PR TITLE
Add systemd cross-compilation for ARM builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,13 @@ bash-image: $(addprefix obj/bash/,$(addsuffix /bash,$(BASH_ARCHES))) build_image
 obj/bash/%/bash:
 	@scripts/build_arm.sh --no-clean
 
+SYSTEMD_ARCHES := arm arm64
+
+systemd-image: $(addprefix obj/systemd/,$(addsuffix /systemd,$(SYSTEMD_ARCHES))) build_images
+
+obj/systemd/%/systemd:
+	@scripts/build_arm.sh --no-clean
+
 EXAMPLE_CRATES := \
 src/ipc-example/client \
 src/ipc-example/server \
@@ -161,8 +168,9 @@ help:
 	@echo "  setup"
 	@echo "  gen_prebuilt"
 	@echo "  bash-image    Build image with Bash as first program"
+	@echo "  systemd-image Build image with systemd"
 	@echo "  examples      Build Rust example servers and clients"
 
 .PHONY: setup all build_all clean help \
 build_images build_fiasco build_l4re build_l4linux bash-image \
-examples
+systemd-image examples

--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -41,6 +41,9 @@ required_tools=(
   "${CROSS_COMPILE_ARM64}gcc"
   mke2fs
   debugfs
+  meson
+  ninja
+  pkg-config
 )
 for tool in "${required_tools[@]}"; do
   if ! command -v "$tool" >/dev/null 2>&1; then
@@ -128,6 +131,58 @@ else
   echo "bash for arm and arm64 already built, skipping"
 fi
 
+# Build systemd for ARM and ARM64
+build_systemd() {
+  local arch="$1" cross="$2" cpu="$3"
+  local out_dir="obj/systemd/$arch"
+  if [ -f "$out_dir/systemd" ]; then
+    echo "systemd for $arch already built, skipping"
+    return
+  fi
+  mkdir -p "$out_dir"
+  (
+    cd "$systemd_src_dir"
+    builddir="build-$arch"
+    rm -rf "$builddir"
+    cat > cross.txt <<EOF
+[binaries]
+c = '${cross}gcc'
+ar = '${cross}ar'
+strip = '${cross}strip'
+
+[host_machine]
+system = 'linux'
+cpu_family = '$cpu'
+cpu = '$cpu'
+endian = 'little'
+EOF
+    meson setup "$builddir" --cross-file cross.txt --prefix=/usr
+    ninja -C "$builddir" systemd || ninja -C "$builddir"
+    DESTDIR="$repo_root/$out_dir/root" meson install -C "$builddir"
+    cp "$repo_root/$out_dir/root/lib/systemd/systemd" "$repo_root/$out_dir/"
+  )
+}
+
+need_systemd=false
+for arch in arm arm64; do
+  if [ ! -f "obj/systemd/$arch/systemd" ]; then
+    need_systemd=true
+    break
+  fi
+done
+
+if [ "$need_systemd" = true ]; then
+  SYSTEMD_VERSION=255.4
+  SYSTEMD_URL="https://github.com/systemd/systemd-stable/archive/refs/tags/v${SYSTEMD_VERSION}.tar.gz"
+  systemd_src_dir=$(mktemp -d src/systemd-XXXXXX)
+  curl -L "$SYSTEMD_URL" | tar -xz -C "$systemd_src_dir" --strip-components=1
+  build_systemd arm "$CROSS_COMPILE_ARM" arm
+  build_systemd arm64 "$CROSS_COMPILE_ARM64" aarch64
+  rm -rf "$systemd_src_dir"
+else
+  echo "systemd for arm and arm64 already built, skipping"
+fi
+
 # Build the tree including libc, Leo, and Rust crates
 make
 
@@ -153,11 +208,42 @@ debugfs -w -R "chmod 0755 /bin/sh" "$lsb_img" >/dev/null
 debugfs -w -R "write obj/bash/arm64/bash /bin/bash" "$lsb_img" >/dev/null
 debugfs -w -R "chmod 0755 /bin/bash" "$lsb_img" >/dev/null
 
+# Install systemd into the root filesystem image and staging area
+sys_root="obj/systemd/arm64/root"
+if [ -d "$sys_root" ]; then
+  mkdir -p files/lsb_root/usr/lib/systemd
+  mkdir -p files/lsb_root/lib/systemd
+  if [ -d "$sys_root/usr/lib/systemd" ]; then
+    cp -r "$sys_root/usr/lib/systemd/"* files/lsb_root/usr/lib/systemd/ 2>/dev/null || true
+  fi
+  if [ -f "$sys_root/lib/systemd/systemd" ]; then
+    cp "$sys_root/lib/systemd/systemd" files/lsb_root/lib/systemd/systemd
+    cp "$sys_root/lib/systemd/systemd" files/lsb_root/usr/lib/systemd/systemd
+    debugfs -w -R "mkdir /lib/systemd" "$lsb_img" >/dev/null
+    debugfs -w -R "mkdir /usr/lib/systemd" "$lsb_img" >/dev/null
+    debugfs -w -R "write $sys_root/lib/systemd/systemd /lib/systemd/systemd" "$lsb_img" >/dev/null
+    debugfs -w -R "chmod 0755 /lib/systemd/systemd" "$lsb_img" >/dev/null
+    debugfs -w -R "write $sys_root/lib/systemd/systemd /usr/lib/systemd/systemd" "$lsb_img" >/dev/null
+    debugfs -w -R "chmod 0755 /usr/lib/systemd/systemd" "$lsb_img" >/dev/null
+    if [ -d "$sys_root/usr/lib/systemd" ]; then
+      find "$sys_root/usr/lib/systemd" -type d | while read -r d; do
+        rel="${d#$sys_root}"
+        debugfs -w -R "mkdir $rel" "$lsb_img" >/dev/null || true
+      done
+      find "$sys_root/usr/lib/systemd" -type f | while read -r f; do
+        rel="${f#$sys_root}"
+        debugfs -w -R "write $f $rel" "$lsb_img" >/dev/null
+        debugfs -w -R "chmod 0644 $rel" "$lsb_img" >/dev/null
+      done
+    fi
+  fi
+fi
+
 # Collect build artifacts
 out_dir="out"
 rm -rf "$out_dir"
 mkdir -p "$out_dir"
-find obj -type f \( -name '*.rlib' -o -name '*.elf' -o -name '*.img' -o -name '*.image' \) -exec cp {} "$out_dir" \;
+find obj -type f \( -name '*.rlib' -o -name '*.elf' -o -name '*.img' -o -name '*.image' -o -name systemd \) -exec cp {} "$out_dir" \;
 cp "$lsb_img" "$out_dir/"
 
 echo "Artifacts placed in $out_dir"

--- a/src/pkg/systemd/Makefile
+++ b/src/pkg/systemd/Makefile
@@ -1,0 +1,16 @@
+PKGDIR ?= .
+L4DIR ?= $(PKGDIR)/../..
+
+TARGET := systemd
+SYSTEMD_BIN := $(PKGDIR)/../../obj/systemd/$(L4ARCH)/systemd
+
+$(TARGET): $(SYSTEMD_BIN)
+	ln -sf $(SYSTEMD_BIN) $(TARGET)
+
+install:: $(TARGET)
+	$(INSTALL) -m 755 $(TARGET) $(INSTDIR)/boot/
+
+clean::
+	$(RM) $(TARGET)
+
+include $(L4DIR)/mk/subdir.mk


### PR DESCRIPTION
## Summary
- Cross-compile systemd for ARM and ARM64 during build_arm.sh
- Package systemd binaries and embed them into the rootfs image
- Add Makefile target for systemd-image

## Testing
- `bash -n scripts/build_arm.sh`
- `make help`
- `./scripts/build_arm.sh --no-clean` *(fails: Required tool arm-linux-gnueabihf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c585cc4df4832fb9fce6adc42d21ed