### PR TITLE
Add fs_server systemd unit and install during build

### DIFF
--- a/files/systemd/fs_server.service
+++ b/files/systemd/fs_server.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=L4Re File Server
+Before=net_server.service
+
+[Service]
+ExecStart=/boot/fs_server
+# Provide capabilities and environment entries needed by fs_server.
+# These map virtio block device and scheduler resources and export the global filesystem gate.
+Environment="L4_CAP_GLOBAL_FS=global_fs" \
+           "L4_CAP_LSB_ROOT=lsb_root" \
+           "L4_CAP_VIRTIO_BLK=virtio_blk" \
+           "L4_CAP_VIRTIO_BLK_IRQ=virtio_blk_irq" \
+           "L4_CAP_IOMEM=iomem" \
+           "L4_CAP_SCHED=scheduler"
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_MKNOD CAP_DAC_OVERRIDE
+AmbientCapabilities=CAP_SYS_ADMIN CAP_MKNOD CAP_DAC_OVERRIDE
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -239,6 +239,16 @@ if [ -d "$sys_root" ]; then
   fi
 fi
 
+# Install fs_server systemd unit into the image
+fs_unit="files/systemd/fs_server.service"
+if [ -f "$fs_unit" ]; then
+  mkdir -p files/lsb_root/lib/systemd/system
+  cp "$fs_unit" files/lsb_root/lib/systemd/system/
+  debugfs -w -R "mkdir /lib/systemd/system" "$lsb_img" >/dev/null || true
+  debugfs -w -R "write $fs_unit /lib/systemd/system/fs_server.service" "$lsb_img" >/dev/null
+  debugfs -w -R "chmod 0644 /lib/systemd/system/fs_server.service" "$lsb_img" >/dev/null
+fi
+
 # Collect build artifacts
 out_dir="out"
 rm -rf "$out_dir"


### PR DESCRIPTION
## Summary
- add fs_server systemd unit that initializes filesystem server before network server
- install fs_server.service into image during build

## Testing
- `bash -n scripts/build_arm.sh`
- `systemd-analyze verify files/systemd/fs_server.service` *(fails: Command /boot/fs_server is not executable)*
- `cargo test` *(fails: 'l4/sys/consts.h' file not found)*
