### PR TITLE
Boot via systemd with exported capabilities

### DIFF
--- a/files/cfg/bash.cfg
+++ b/files/cfg/bash.cfg
@@ -1,52 +1,28 @@
 local L4 = require("L4")
 local ld = L4.default_loader
 
--- allocate a communication channel for the filesystem server
+-- Allocate communication channels for system-wide services
 local fs_chan = ld:new_channel()
-
--- allocate a communication channel for the network server
 local net_chan = ld:new_channel()
-
--- allocate a communication channel for the LSB root filesystem
 local lsb_root = ld:new_channel()
 
--- start the file system server with the required capabilities so it can
--- access the virtio block device and publish its IPC gate as "global_fs"
+-- Start systemd (/sbin/init) and export capability handles so that
+-- it can launch the actual servers and clients.
 ld:start({
-  log = {"fs_server", "green"},
+  log = {"init", "yellow"},
   caps = {
     -- server side of the global filesystem gate
     global_fs = fs_chan:svr(),
-    -- server side of the LSB root gate so clients can look it up as "lsb_root"
-    lsb_root = lsb_root:svr(),
-    -- grant access to the virtio block device and its interrupt
-    virtio_blk = L4.Env.virtio_blk,
-    virtio_blk_irq = L4.Env.virtio_blk_irq,
-    -- allow mapping of IO memory and scheduling
-    iomem = L4.Env.sigma0,
-    scheduler = L4.Env.sched,
-  }
-}, "rom/fs_server")
-
--- start the network server and publish its IPC gate as "global_net"
-ld:start({
-  log = {"net_server", "blue"},
-  caps = {
     -- server side of the global network gate
     global_net = net_chan:svr(),
-    -- grant access to the virtio network device and its interrupt
+    -- server side of the LSB root gate
+    lsb_root = lsb_root:svr(),
+    -- provide hardware device and kernel interfaces for services
+    virtio_blk = L4.Env.virtio_blk,
+    virtio_blk_irq = L4.Env.virtio_blk_irq,
     virtio_net = L4.Env.virtio_net,
     virtio_net_irq = L4.Env.virtio_net_irq,
-    -- allow mapping of IO memory and scheduling
     iomem = L4.Env.sigma0,
     scheduler = L4.Env.sched,
   }
-}, "rom/net_server")
-
--- launch bash afterwards. The client side of the global_fs channel is passed
--- so programs can look it up from their environment and talk to the servers.
-ld:start({
-  log = {"bash", "yellow"},
-  caps = { global_fs = fs_chan, global_net = net_chan, lsb_root = lsb_root }
-}, "rom/bash")
-
+}, "/sbin/init")

--- a/runqemu.sh
+++ b/runqemu.sh
@@ -1,1 +1,1 @@
-./src/l4/tool/bin/l4image -i obj/l4/arm64/images/bootstrap_bash_arm_virt.elf launch
+./src/l4/tool/bin/l4image -i obj/l4/arm64/images/bootstrap_systemd_arm_virt.elf launch


### PR DESCRIPTION
## Summary
- Replace direct fs, net, and bash launches with a single `/sbin/init` start, exporting filesystem, network, and LSB root capabilities for systemd-managed services
- Update QEMU helper script to boot the systemd image

## Testing
- `luac -p files/cfg/bash.cfg`
- `bash -n runqemu.sh`
