### PR TITLE
Add SSH setup to ARM build

### DIFF
--- a/files/lsb_root/etc/ssh/sshd_config
+++ b/files/lsb_root/etc/ssh/sshd_config
@@ -1,0 +1,3 @@
+PermitRootLogin yes
+HostKey /etc/ssh/ssh_host_rsa_key
+


### PR DESCRIPTION
## Summary
- generate SSH host keys and config in ARM build script
- include ssh-keygen in required tools list
- add minimal sshd_config for root filesystem

## Testing
- `bash -n scripts/build_arm.sh`
- `cargo test --manifest-path src/l4rust/core-ffi-helpers/Cargo.toml`
