### PR TITLE
Add AUTOSAR scheduler with priority inheritance and L4Re integration

### DIFF
--- a/src/l4rust/l4-rust/scheduler/autosar.rs
+++ b/src/l4rust/l4-rust/scheduler/autosar.rs
@@ -1,0 +1,238 @@
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::vec::Vec;
+use core::cmp::min;
+
+use super::SchedulerPolicy;
+
+#[cfg(not(test))]
+use l4_sys::{l4_cap_idx_t, l4_sched_param_t, run_thread};
+#[cfg(test)]
+type l4_cap_idx_t = usize;
+
+#[derive(Clone)]
+struct Task {
+    period: u64,
+    base_priority: u64,
+    current_priority: u64,
+    #[allow(dead_code)]
+    thread_cap: l4_cap_idx_t,
+    owned_mutexes: BTreeSet<usize>,
+}
+
+struct MutexState {
+    owner: Option<usize>,
+    waiters: Vec<usize>,
+}
+
+pub struct AutosarScheduler {
+    scheduler_cap: l4_cap_idx_t,
+    tasks: BTreeMap<usize, Task>,
+    ready: Vec<usize>,
+    current: Option<usize>,
+    mutexes: BTreeMap<usize, MutexState>,
+}
+
+impl AutosarScheduler {
+    pub fn new(scheduler_cap: l4_cap_idx_t) -> Self {
+        Self {
+            scheduler_cap,
+            tasks: BTreeMap::new(),
+            ready: Vec::new(),
+            current: None,
+            mutexes: BTreeMap::new(),
+        }
+    }
+
+    pub fn add_task(&mut self, id: usize, period: u64, thread_cap: l4_cap_idx_t) {
+        let task = Task {
+            period,
+            base_priority: period,
+            current_priority: period,
+            thread_cap,
+            owned_mutexes: BTreeSet::new(),
+        };
+        self.tasks.insert(id, task);
+    }
+
+    fn insert_ready_sorted(&mut self, id: usize) {
+        let prio = self.tasks[&id].current_priority;
+        let pos = self
+            .ready
+            .binary_search_by_key(&prio, |tid| self.tasks[tid].current_priority)
+            .unwrap_or_else(|e| e);
+        self.ready.insert(pos, id);
+    }
+
+    pub fn make_ready(&mut self, id: usize) {
+        if self.current == Some(id) || self.ready.contains(&id) {
+            return;
+        }
+        self.insert_ready_sorted(id);
+        if let Some(cur) = self.current {
+            let cur_prio = self.tasks[&cur].current_priority;
+            let new_prio = self.tasks[&id].current_priority;
+            if new_prio < cur_prio {
+                self.preempt();
+            }
+        } else {
+            self.run_next();
+        }
+    }
+
+    fn preempt(&mut self) {
+        if let Some(cur) = self.current.take() {
+            self.insert_ready_sorted(cur);
+        }
+        self.run_next();
+    }
+
+    fn run_next(&mut self) {
+        if let Some(next_id) = self.ready.first().cloned() {
+            self.ready.remove(0);
+            self.current = Some(next_id);
+            #[cfg(not(test))]
+            unsafe {
+                run_thread(
+                    self.scheduler_cap,
+                    self.tasks[&next_id].thread_cap,
+                    core::ptr::null_mut::<l4_sched_param_t>(),
+                );
+            }
+        }
+    }
+
+    pub fn lock_mutex(&mut self, task: usize, mutex: usize) {
+        let m = self.mutexes.entry(mutex).or_insert(MutexState {
+            owner: None,
+            waiters: Vec::new(),
+        });
+        if m.owner.is_none() {
+            m.owner = Some(task);
+            self.tasks
+                .get_mut(&task)
+                .unwrap()
+                .owned_mutexes
+                .insert(mutex);
+        } else {
+            self.ready.retain(|&tid| tid != task);
+            let prio = self.tasks[&task].current_priority;
+            let pos = m
+                .waiters
+                .binary_search_by_key(&prio, |tid| self.tasks[tid].current_priority)
+                .unwrap_or_else(|e| e);
+            m.waiters.insert(pos, task);
+            let owner = m.owner.unwrap();
+            {
+                let owner_task = self.tasks.get_mut(&owner).unwrap();
+                owner_task.current_priority = min(owner_task.current_priority, prio);
+            }
+            if self.ready.contains(&owner) {
+                self.ready.retain(|&tid| tid != owner);
+                self.insert_ready_sorted(owner);
+            }
+            if self.current == Some(task) {
+                self.current = None;
+                self.run_next();
+            }
+        }
+    }
+
+    pub fn unlock_mutex(&mut self, task: usize, mutex: usize) {
+        if let Some(m) = self.mutexes.get_mut(&mutex) {
+            if m.owner == Some(task) {
+                if let Some(next) = m.waiters.first().cloned() {
+                    m.waiters.remove(0);
+                    m.owner = Some(next);
+                    self.tasks
+                        .get_mut(&next)
+                        .unwrap()
+                        .owned_mutexes
+                        .insert(mutex);
+                    self.make_ready(next);
+                } else {
+                    m.owner = None;
+                }
+                self.tasks
+                    .get_mut(&task)
+                    .unwrap()
+                    .owned_mutexes
+                    .remove(&mutex);
+                let new_prio = self.tasks[&task].owned_mutexes.iter().fold(
+                    self.tasks[&task].base_priority,
+                    |p, &m_id| {
+                        if let Some(mstate) = self.mutexes.get(&m_id) {
+                            if let Some(waiter) = mstate.waiters.first() {
+                                min(p, self.tasks[waiter].current_priority)
+                            } else {
+                                p
+                            }
+                        } else {
+                            p
+                        }
+                    },
+                );
+                {
+                    let t = self.tasks.get_mut(&task).unwrap();
+                    t.current_priority = new_prio;
+                }
+                if self.ready.contains(&task) {
+                    self.ready.retain(|&tid| tid != task);
+                    self.insert_ready_sorted(task);
+                } else if self.current == Some(task) {
+                    if let Some(&next_id) = self.ready.first() {
+                        let next_prio = self.tasks[&next_id].current_priority;
+                        if next_prio < self.tasks[&task].current_priority {
+                            self.preempt();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn current_task(&self) -> Option<usize> {
+        self.current
+    }
+
+    pub fn task_priority(&self, id: usize) -> u64 {
+        self.tasks[&id].current_priority
+    }
+}
+
+impl SchedulerPolicy for AutosarScheduler {
+    fn name(&self) -> &'static str {
+        "autosar"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn period_based_preemption() {
+        let mut s = AutosarScheduler::new(0);
+        s.add_task(1, 100, 0); // higher priority
+        s.add_task(2, 200, 0); // lower priority
+        s.make_ready(2);
+        assert_eq!(s.current_task(), Some(2));
+        s.make_ready(1);
+        assert_eq!(s.current_task(), Some(1));
+    }
+
+    #[test]
+    fn priority_inheritance() {
+        let mut s = AutosarScheduler::new(0);
+        s.add_task(1, 200, 0); // low priority
+        s.add_task(2, 100, 0); // high priority
+        s.make_ready(1);
+        s.lock_mutex(1, 1);
+        s.make_ready(2);
+        s.lock_mutex(2, 1); // blocks and boosts task 1
+        assert_eq!(s.current_task(), Some(1));
+        assert_eq!(s.task_priority(1), s.task_priority(2));
+        s.unlock_mutex(1, 1);
+        assert_eq!(s.current_task(), Some(2));
+        assert_eq!(s.task_priority(1), 200);
+    }
+}

--- a/src/l4rust/l4-rust/scheduler/mod.rs
+++ b/src/l4rust/l4-rust/scheduler/mod.rs
@@ -61,18 +61,7 @@ pub fn from_env() -> Option<Box<dyn SchedulerPolicy>> {
 }
 
 #[cfg(feature = "autosar")]
-mod autosar {
-    use super::SchedulerPolicy;
-
-    /// Placeholder implementation for an AUTOSAR-like scheduler.
-    pub struct AutosarScheduler;
-
-    impl SchedulerPolicy for AutosarScheduler {
-        fn name(&self) -> &'static str {
-            "autosar"
-        }
-    }
-}
+mod autosar;
 
 #[cfg(feature = "linux_like")]
 mod linux_like {
@@ -87,4 +76,3 @@ mod linux_like {
         }
     }
 }
-

--- a/src/l4rust/l4-sys-rust/scheduler.rs
+++ b/src/l4rust/l4-sys-rust/scheduler.rs
@@ -1,14 +1,35 @@
 use crate::c_api::*;
 
-pub unsafe fn l4_scheduler_run_thread(scheduler: l4_cap_idx_t, thread: l4_cap_idx_t, sp: *mut l4_sched_param_t ) -> l4_msgtag_t {
+/// Start execution of `thread` under the given `scheduler` or adjust its
+/// scheduling parameters.
+pub unsafe fn run_thread(
+    scheduler: l4_cap_idx_t,
+    thread: l4_cap_idx_t,
+    sp: *mut l4_sched_param_t,
+) -> l4_msgtag_t {
     l4_scheduler_run_thread_w(scheduler, thread, sp)
 }
 
+/// Preempt the currently running thread and switch to `thread`.
+///
+/// This is a thin wrapper around [`run_thread`] that clarifies intent at the
+/// call site.
+pub unsafe fn preempt_thread(
+    scheduler: l4_cap_idx_t,
+    thread: l4_cap_idx_t,
+    sp: *mut l4_sched_param_t,
+) -> l4_msgtag_t {
+    l4_scheduler_run_thread_w(scheduler, thread, sp)
+}
 
 /// The granularity defines how many CPUs each bit in map describes. And the
 ///    offset is the number of the first CPU described by the first bit in the
 ///    bitmap.
 /// \pre offset must be a multiple of 2^granularity.
-pub unsafe fn l4_sched_cpu_set(offset: l4_umword_t, granularity: u8, map: l4_umword_t) -> l4_sched_cpu_set_t {
+pub unsafe fn l4_sched_cpu_set(
+    offset: l4_umword_t,
+    granularity: u8,
+    map: l4_umword_t,
+) -> l4_sched_cpu_set_t {
     l4_sched_cpu_set_w(offset, granularity, map)
 }


### PR DESCRIPTION
## Summary
- implement AUTOSAR scheduler with period-based priorities, ready queues and priority inheritance
- expose L4Re thread run/preemption wrappers
- add unit tests for preemption and priority inheritance

## Testing
- `cargo test --features autosar` *(fails: bindgen.h:2:10: fatal error: 'l4/sys/consts.h' file not found)*

