### PR TITLE
Add virtio frontend crate with C ABI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["driver_picker", "src/linux_shims", "src/driver"]
+members = ["driver_picker", "src/linux_shims", "src/driver", "src/virtio_frontend"]

--- a/src/virtio_frontend/Cargo.toml
+++ b/src/virtio_frontend/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "virtio_frontend"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "virtio_frontend"
+crate-type = ["rlib", "cdylib"]

--- a/src/virtio_frontend/src/ffi.rs
+++ b/src/virtio_frontend/src/ffi.rs
@@ -1,0 +1,66 @@
+use crate::queue::VirtqDesc;
+use crate::transport::VirtioTransport;
+
+/// Create a new transport instance for use from C.
+#[no_mangle]
+pub extern "C" fn virtio_transport_create(
+    device_features: u64,
+    config_len: usize,
+) -> *mut VirtioTransport {
+    Box::into_raw(Box::new(VirtioTransport::new(device_features, config_len)))
+}
+
+/// Destroy a transport previously created via [`virtio_transport_create`].
+#[no_mangle]
+pub unsafe extern "C" fn virtio_transport_destroy(transport: *mut VirtioTransport) {
+    if !transport.is_null() {
+        drop(Box::from_raw(transport));
+    }
+}
+
+/// Negotiate features using a C ABI.
+#[no_mangle]
+pub unsafe extern "C" fn virtio_negotiate_features(
+    transport: *mut VirtioTransport,
+    driver_supported: u64,
+) -> u64 {
+    (*transport).negotiate_features(driver_supported)
+}
+
+/// Read from the configuration space using raw pointers.
+#[no_mangle]
+pub unsafe extern "C" fn virtio_config_read(
+    transport: *const VirtioTransport,
+    offset: usize,
+    buf: *mut u8,
+    len: usize,
+) {
+    let slice = core::slice::from_raw_parts_mut(buf, len);
+    (*transport).read_config(offset, slice);
+}
+
+/// Write to the configuration space using raw pointers.
+#[no_mangle]
+pub unsafe extern "C" fn virtio_config_write(
+    transport: *mut VirtioTransport,
+    offset: usize,
+    buf: *const u8,
+    len: usize,
+) {
+    let slice = core::slice::from_raw_parts(buf, len);
+    (*transport).write_config(offset, slice);
+}
+
+/// Add a descriptor chain to the transport's queue. Returns 0 on success.
+#[no_mangle]
+pub unsafe extern "C" fn virtio_queue_add(
+    transport: *mut VirtioTransport,
+    descs: *const VirtqDesc,
+    count: usize,
+) -> i32 {
+    let slice = core::slice::from_raw_parts(descs, count);
+    match (*transport).queue.add(slice) {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
+}

--- a/src/virtio_frontend/src/lib.rs
+++ b/src/virtio_frontend/src/lib.rs
@@ -1,0 +1,61 @@
+pub mod ffi;
+pub mod queue;
+pub mod transport;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn feature_negotiation() {
+        let mut dev = transport::VirtioTransport::new(0b1010, 0);
+        let features = dev.negotiate_features(0b1110);
+        assert_eq!(features, 0b1010 & 0b1110);
+    }
+
+    #[test]
+    fn config_space_rw() {
+        let mut dev = transport::VirtioTransport::new(0, 8);
+        dev.write_config(2, &[1, 2, 3, 4]);
+        let mut buf = [0u8; 4];
+        dev.read_config(2, &mut buf);
+        assert_eq!(&buf, &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn queue_add_descriptor() {
+        let mut dev = transport::VirtioTransport::new(0, 0);
+        let descs = [
+            queue::VirtqDesc {
+                addr: 0x1000,
+                len: 16,
+                flags: 0x0002,
+                next: 1,
+            },
+            queue::VirtqDesc {
+                addr: 0x2000,
+                len: 32,
+                flags: 0,
+                next: 0,
+            },
+        ];
+        dev.queue.add(&descs).unwrap();
+        assert_eq!(dev.queue.avail.idx, 1);
+        assert_eq!(dev.queue.desc[0].addr, 0x1000);
+    }
+
+    #[test]
+    fn ffi_roundtrip() {
+        unsafe {
+            let dev = ffi::virtio_transport_create(0b1, 4);
+            let neg = ffi::virtio_negotiate_features(dev, 0b11);
+            assert_eq!(neg, 0b1);
+            let value = [0xAAu8];
+            ffi::virtio_config_write(dev, 0, value.as_ptr(), value.len());
+            let mut out = [0u8];
+            ffi::virtio_config_read(dev, 0, out.as_mut_ptr(), out.len());
+            assert_eq!(out[0], 0xAA);
+            ffi::virtio_transport_destroy(dev);
+        }
+    }
+}

--- a/src/virtio_frontend/src/queue.rs
+++ b/src/virtio_frontend/src/queue.rs
@@ -1,0 +1,85 @@
+/// Structures implementing a very small virtqueue similar to the ones used in
+/// existing server implementations.
+
+const QUEUE_SIZE: usize = 8;
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct VirtqDesc {
+    pub addr: u64,
+    pub len: u32,
+    pub flags: u16,
+    pub next: u16,
+}
+
+#[repr(C)]
+pub struct VirtqAvail {
+    pub flags: u16,
+    pub idx: u16,
+    pub ring: [u16; QUEUE_SIZE],
+    pub used_event: u16,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct VirtqUsedElem {
+    pub id: u32,
+    pub len: u32,
+}
+
+#[repr(C)]
+pub struct VirtqUsed {
+    pub flags: u16,
+    pub idx: u16,
+    pub ring: [VirtqUsedElem; QUEUE_SIZE],
+    pub avail_event: u16,
+}
+
+/// Simple descriptor ring for demonstration purposes.
+pub struct VirtQueue {
+    pub desc: [VirtqDesc; QUEUE_SIZE],
+    pub avail: VirtqAvail,
+    pub used: VirtqUsed,
+}
+
+impl VirtQueue {
+    pub const fn new() -> Self {
+        const DESC: VirtqDesc = VirtqDesc {
+            addr: 0,
+            len: 0,
+            flags: 0,
+            next: 0,
+        };
+        const USED_ELEM: VirtqUsedElem = VirtqUsedElem { id: 0, len: 0 };
+        Self {
+            desc: [DESC; QUEUE_SIZE],
+            avail: VirtqAvail {
+                flags: 0,
+                idx: 0,
+                ring: [0; QUEUE_SIZE],
+                used_event: 0,
+            },
+            used: VirtqUsed {
+                flags: 0,
+                idx: 0,
+                ring: [USED_ELEM; QUEUE_SIZE],
+                avail_event: 0,
+            },
+        }
+    }
+
+    /// Place a descriptor chain into the available ring. The descriptors are
+    /// copied into the descriptor table starting at index 0.
+    pub fn add(&mut self, chain: &[VirtqDesc]) -> Result<u16, ()> {
+        if chain.len() > QUEUE_SIZE {
+            return Err(());
+        }
+        for (i, d) in chain.iter().enumerate() {
+            self.desc[i] = *d;
+        }
+        let idx = self.avail.idx as usize % QUEUE_SIZE;
+        self.avail.ring[idx] = 0;
+        self.avail.idx = self.avail.idx.wrapping_add(1);
+        Ok(idx as u16)
+    }
+}

--- a/src/virtio_frontend/src/transport.rs
+++ b/src/virtio_frontend/src/transport.rs
@@ -1,0 +1,42 @@
+use crate::queue::VirtQueue;
+
+/// Simple virtio transport exposing feature negotiation, config space access
+/// and a single virtqueue.
+pub struct VirtioTransport {
+    pub device_features: u64,
+    pub driver_features: u64,
+    config: Vec<u8>,
+    pub queue: VirtQueue,
+}
+
+impl VirtioTransport {
+    /// Create a new transport with the given device features and config space
+    /// size in bytes.
+    pub fn new(device_features: u64, config_len: usize) -> Self {
+        Self {
+            device_features,
+            driver_features: 0,
+            config: vec![0; config_len],
+            queue: VirtQueue::new(),
+        }
+    }
+
+    /// Negotiate features with the driver. Returns the agreed upon feature set.
+    pub fn negotiate_features(&mut self, driver_supported: u64) -> u64 {
+        let negotiated = self.device_features & driver_supported;
+        self.driver_features = negotiated;
+        negotiated
+    }
+
+    /// Read from the virtual device configuration space.
+    pub fn read_config(&self, offset: usize, data: &mut [u8]) {
+        assert!(offset + data.len() <= self.config.len());
+        data.copy_from_slice(&self.config[offset..offset + data.len()]);
+    }
+
+    /// Write to the virtual device configuration space.
+    pub fn write_config(&mut self, offset: usize, data: &[u8]) {
+        assert!(offset + data.len() <= self.config.len());
+        self.config[offset..offset + data.len()].copy_from_slice(data);
+    }
+}


### PR DESCRIPTION
## Summary
- add `virtio_frontend` crate offering virtqueue structures, feature negotiation and config space helpers
- expose safe Rust API and C ABI wrappers for use by extracted C drivers
- include unit tests covering feature negotiation, config access, queue ops and FFI

## Testing
- `cargo fmt -p virtio_frontend`
- `cargo test -p virtio_frontend`
