### PR TITLE
Add driver wrapper helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,51 @@ make
 
 Ensuring `LIBRARY_PATH` is set correctly allows the Rust crates to link against
 the freshly built static libc.
+
+## Driver packaging workflow
+
+The `tools/l4re-driver-wrap` helper bundles driver selection, build scaffolding
+generation, compilation of the virtio-enabled server, and L4Re packaging into a
+single command. It produces a package under `src/pkg/<driver>/` that can be
+consumed by the L4Re build system.
+
+### Basic usage
+
+```
+tools/l4re-driver-wrap --linux-src /path/to/linux
+```
+
+The script launches an interactive selector to choose a driver from the Linux
+source tree. After extraction, the driver is wrapped and a package directory is
+created.
+
+### Using a configuration file
+
+Re-running the workflow for a different driver can be automated via a simple
+configuration file:
+
+```
+cat >driver.conf <<EOF
+LINUX_SRC=/home/user/linux
+DRIVER=e1000
+EOF
+
+tools/l4re-driver-wrap --config driver.conf
+```
+
+The `DRIVER` variable controls the package name. If omitted, the name from the
+generated manifest is used.
+
+### Troubleshooting
+
+* Ensure the `driver_picker` tool builds successfully and that `LINUX_SRC`
+  points to a valid kernel tree.
+* If compilation fails, verify that cross-compilation toolchains referenced by
+  the `CROSS_COMPILE` environment variable are installed.
+* Packaging errors usually indicate the build step did not produce the expected
+  `target/release/driver_server` binary; rerun the build after fixing the
+  underlying issue.
+
 ## Systemd integration
 
 The build scripts can produce a systemd-based image. `scripts/build_arm.sh` fetches and cross-builds systemd for arm and arm64, then installs it together with unit files from `files/systemd` into the root filesystem. The same process can be invoked with `make systemd-image`.

--- a/src/driver/Cargo.toml
+++ b/src/driver/Cargo.toml
@@ -12,3 +12,4 @@ linux_shims = { path = "../linux_shims" }
 
 [build-dependencies]
 cc = "1"
+walkdir = "2"

--- a/src/driver/build.rs
+++ b/src/driver/build.rs
@@ -1,12 +1,24 @@
 use std::env;
+use walkdir::WalkDir;
 
 fn main() {
     let mut build = cc::Build::new();
     build
-        .file("driver.c")
         .flag("-ffreestanding")
         .flag("-fno-builtin")
         .flag("-nostdlib");
+
+    for entry in WalkDir::new("src") {
+        let entry = entry.unwrap();
+        if entry.file_type().is_file() {
+            if let Some(ext) = entry.path().extension() {
+                if ext == "c" {
+                    build.file(entry.path());
+                }
+            }
+        }
+    }
+
     // Mirror CROSS_COMPILE setup from scripts/build_arm.sh
     if let Ok(prefix) = env::var("CROSS_COMPILE") {
         build.compiler(format!("{}gcc", prefix));

--- a/tools/l4re-driver-wrap
+++ b/tools/l4re-driver-wrap
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--config FILE] [--linux-src PATH] [--driver NAME]
+
+Combines driver selection, scaffolding, build, and packaging into one step.
+
+Options:
+  --config FILE     Configuration file with LINUX_SRC and DRIVER variables
+  --linux-src PATH  Path to Linux kernel sources
+  --driver NAME     Driver name for packaging (defaults to manifest value)
+  -h, --help        Show this help
+USAGE
+}
+
+CONFIG=""
+LINUX_SRC=""
+DRIVER=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)
+      CONFIG="$2"
+      shift 2
+      ;;
+    --linux-src)
+      LINUX_SRC="$2"
+      shift 2
+      ;;
+    --driver)
+      DRIVER="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "$CONFIG" ]]; then
+  if [[ -f "$CONFIG" ]]; then
+    source "$CONFIG"
+  else
+    echo "Config file $CONFIG not found" >&2
+    exit 1
+  fi
+fi
+
+if [[ -z "${LINUX_SRC:-}" ]]; then
+  echo "LINUX_SRC not specified" >&2
+  exit 1
+fi
+
+# Step 1: run driver_picker selection/extraction tool
+picker_output=$(cargo run --manifest-path driver_picker/Cargo.toml -- --linux-src "$LINUX_SRC")
+echo "$picker_output"
+workspace=$(echo "$picker_output" | sed -n 's/^Workspace: //p' | tail -n1)
+manifest="$workspace/driver.yaml"
+
+if [[ -z "$workspace" || ! -f "$manifest" ]]; then
+  echo "Failed to determine extraction workspace" >&2
+  exit 1
+fi
+
+if [[ -z "${DRIVER:-}" ]]; then
+  DRIVER=$(grep '^driver:' "$manifest" | awk '{print $2}')
+fi
+
+# Step 2: generate build scaffolding by copying sources
+src_dir="src/driver/src/linux"
+rm -rf "$src_dir"
+mkdir -p "$src_dir"
+cp -r "$workspace"/* "$src_dir/"
+cp "$manifest" "$src_dir/"
+
+echo "Scaffolding generated under $src_dir"
+
+# Step 3: build virtio-enabled driver server
+cargo build --manifest-path src/driver_server/Cargo.toml --release
+
+# Step 4: create L4Re package
+pkg_dir="src/pkg/$DRIVER"
+mkdir -p "$pkg_dir"
+cat > "$pkg_dir/Makefile" <<PKG
+PKGDIR ?= .
+L4DIR ?= \$(PKGDIR)/../..
+
+TARGET := $DRIVER
+
+install:: \$(TARGET)
+\$(INSTALL) -m 755 \$(TARGET) \$(INSTDIR)/boot/
+
+include \$(L4DIR)/mk/subdir.mk
+PKG
+
+cp target/release/driver_server "$pkg_dir/$DRIVER"
+
+echo "Package created at $pkg_dir"


### PR DESCRIPTION
## Summary
- add `tools/l4re-driver-wrap` to extract Linux drivers, generate scaffolding, build the virtio server, and produce an L4Re package
- teach driver build script to compile all C sources and add `walkdir` dependency
- document driver wrapping workflow in `README.md`

## Testing
- ❌ `cargo check --manifest-path src/driver/Cargo.toml` (failed: C-variadic function errors in linux_shims)
- ❌ `cargo check --manifest-path src/driver_server/Cargo.toml` (failed: cc-rs could not archive libdriver.a)


------
https://chatgpt.com/codex/tasks/task_e_68c5c95f4ce0832fbb2e81ee47829ba0