### PR TITLE
Implement printk logging and module lifecycle management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "linux_shims",
+ "walkdir",
 ]
 
 [[package]]
@@ -475,6 +476,10 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "virtio_frontend"
+version = "0.1.0"
 
 [[package]]
 name = "walkdir"

--- a/src/linux_shims/src/lib.rs
+++ b/src/linux_shims/src/lib.rs
@@ -1,19 +1,101 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
+#![feature(c_variadic)]
 
-use core::ffi::c_char;
+use core::ffi::{c_char, VaListImpl};
+use core::sync::atomic::{AtomicBool, Ordering};
+
+extern "C" {
+    fn vprintf(fmt: *const c_char, args: VaListImpl) -> i32;
+}
+
+static INIT_DONE: AtomicBool = AtomicBool::new(false);
+static mut EXIT_HANDLER: Option<extern "C" fn()> = None;
+
 #[no_mangle]
-pub extern "C" fn printk(_fmt: *const c_char, _args: ...) {
-    // Stub: ignore kernel print statements
+pub unsafe extern "C" fn printk(fmt: *const c_char, args: ...) {
+    vprintf(fmt, args);
 }
 
 #[no_mangle]
-pub extern "C" fn module_init(_init: extern "C" fn() -> i32) {
-    // Stub: immediately invoke init function
-    let _ = _init();
+pub extern "C" fn module_init(init: extern "C" fn() -> i32) {
+    if INIT_DONE
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+    if init() != 0 {
+        INIT_DONE.store(false, Ordering::SeqCst);
+    }
 }
 
 #[no_mangle]
-pub extern "C" fn module_exit(_exit: extern "C" fn()) {
-    // Stub: invoke exit function on module unload
-    _exit();
+pub extern "C" fn module_exit(exit: extern "C" fn()) {
+    unsafe {
+        if INIT_DONE.load(Ordering::SeqCst) {
+            EXIT_HANDLER = Some(exit);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn module_shutdown() {
+    if INIT_DONE.swap(false, Ordering::SeqCst) {
+        unsafe {
+            if let Some(handler) = EXIT_HANDLER {
+                handler();
+                EXIT_HANDLER = None;
+            }
+        }
+    }
+}
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    static INIT_COUNT: AtomicUsize = AtomicUsize::new(0);
+    static EXIT_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    extern "C" fn init_ok() -> i32 {
+        INIT_COUNT.fetch_add(1, Ordering::SeqCst);
+        0
+    }
+
+    extern "C" fn init_fail() -> i32 {
+        INIT_COUNT.fetch_add(1, Ordering::SeqCst);
+        1
+    }
+
+    extern "C" fn exit_fn() {
+        EXIT_COUNT.fetch_add(1, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn shutdown_runs_exit_on_success() {
+        INIT_COUNT.store(0, Ordering::SeqCst);
+        EXIT_COUNT.store(0, Ordering::SeqCst);
+        module_init(init_ok);
+        module_exit(exit_fn);
+        module_shutdown();
+        assert_eq!(INIT_COUNT.load(Ordering::SeqCst), 1);
+        assert_eq!(EXIT_COUNT.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn failed_init_skips_exit() {
+        INIT_COUNT.store(0, Ordering::SeqCst);
+        EXIT_COUNT.store(0, Ordering::SeqCst);
+        module_init(init_fail);
+        module_exit(exit_fn);
+        module_shutdown();
+        assert_eq!(INIT_COUNT.load(Ordering::SeqCst), 1);
+        assert_eq!(EXIT_COUNT.load(Ordering::SeqCst), 0);
+    }
 }


### PR DESCRIPTION
## Summary
- forward `printk` to libc `vprintf`
- track module initialization and registered exit handler
- add `module_shutdown` helper and tests for lifecycle

## Testing
- `cargo +nightly test -p linux_shims` *(fails: unwinding panics are not supported without std)*

