### PR TITLE
Use mktemp for temp file in setup script

### DIFF
--- a/setup
+++ b/setup
@@ -128,7 +128,7 @@ do_config()
 
   if command -v dialog; then
 
-    tmpfile=`tempfile 2>/dev/null` || tmpfile=/tmp/test$$
+    tmpfile=$(mktemp)
     trap "rm -f $tmpfile" 0 1 2 5 15
 
     dialog \


### PR DESCRIPTION
## Summary
- avoid reliance on the external `tempfile` utility by using `mktemp`
- keep trap cleanup for generated temp files

## Testing
- `bash -n setup`
- `printf '\n' | SETUP_CONFIG_ALL=1 CROSS_COMPILE=foo- ./setup config`

