### PR TITLE
Support macOS cross compiler prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ make
 Ensuring `LIBRARY_PATH` is set correctly allows the Rust crates to link against
 the freshly built static libc.
 
+### Cross-compilation toolchains
+
+Both the `setup` script and `scripts/build_arm.sh` look for compiler prefixes
+via the `CROSS_COMPILE_ARM` and `CROSS_COMPILE_ARM64` environment variables.
+Typical prefixes include `arm-linux-gnueabihf-` and `aarch64-linux-gnu-` on
+Linux hosts, or Homebrew's `arm-none-eabi-` and `aarch64-none-elf-` on macOS.
+When these variables are unset, the scripts attempt to choose sensible defaults
+based on `uname`.
+
 ## Driver packaging workflow
 
 The `tools/l4re-driver-wrap` helper bundles driver selection, build scaffolding

--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -29,10 +29,27 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Validate required tools
-CROSS_COMPILE_ARM=${CROSS_COMPILE_ARM:-arm-linux-gnueabihf-}
-CROSS_COMPILE_ARM64=${CROSS_COMPILE_ARM64:-aarch64-linux-gnu-}
+# Determine cross-compilers
+if [ -z "${CROSS_COMPILE_ARM:-}" ] || [ -z "${CROSS_COMPILE_ARM64:-}" ]; then
+  case "$(uname -s)" in
+  Darwin)
+    CROSS_COMPILE_ARM=${CROSS_COMPILE_ARM:-arm-none-eabi-}
+    if [ -z "${CROSS_COMPILE_ARM64:-}" ]; then
+      if command -v aarch64-unknown-linux-gnu-gcc >/dev/null 2>&1; then
+        CROSS_COMPILE_ARM64=aarch64-unknown-linux-gnu-
+      else
+        CROSS_COMPILE_ARM64=aarch64-none-elf-
+      fi
+    fi
+    ;;
+  *)
+    CROSS_COMPILE_ARM=${CROSS_COMPILE_ARM:-arm-linux-gnueabihf-}
+    CROSS_COMPILE_ARM64=${CROSS_COMPILE_ARM64:-aarch64-linux-gnu-}
+    ;;
+  esac
+fi
 
+# Validate required tools
 required_tools=(
   git
   make

--- a/setup
+++ b/setup
@@ -114,12 +114,20 @@ do_config()
     #CONF_DO_MIPS64R2=1
     #CONF_DO_MIPS64R6=1
 
-    CROSS_COMPILE_ARM=arm-linux-gnueabihf-
-    CROSS_COMPILE_ARM64=aarch64-linux-gnu-
-    CROSS_COMPILE_MIPS32R2=mips-linux-
-    CROSS_COMPILE_MIPS32R6=mips-linux-
-    CROSS_COMPILE_MIPS64R2=mips-linux-
-    CROSS_COMPILE_MIPS64R6=mips-linux-
+    case "$(uname -s)" in
+    Darwin)
+      CROSS_COMPILE_ARM=${CROSS_COMPILE_ARM:-arm-none-eabi-}
+      CROSS_COMPILE_ARM64=${CROSS_COMPILE_ARM64:-$(command -v aarch64-unknown-linux-gnu-gcc >/dev/null 2>&1 && echo aarch64-unknown-linux-gnu- || echo aarch64-none-elf-)}
+      ;;
+    *)
+      CROSS_COMPILE_ARM=${CROSS_COMPILE_ARM:-arm-linux-gnueabihf-}
+      CROSS_COMPILE_ARM64=${CROSS_COMPILE_ARM64:-aarch64-linux-gnu-}
+      ;;
+    esac
+    CROSS_COMPILE_MIPS32R2=${CROSS_COMPILE_MIPS32R2:-mips-linux-}
+    CROSS_COMPILE_MIPS32R6=${CROSS_COMPILE_MIPS32R6:-mips-linux-}
+    CROSS_COMPILE_MIPS64R2=${CROSS_COMPILE_MIPS64R2:-mips-linux-}
+    CROSS_COMPILE_MIPS64R6=${CROSS_COMPILE_MIPS64R6:-mips-linux-}
 
     write_config
     return 0;


### PR DESCRIPTION
## Summary
- pick macOS-friendly compiler prefixes in `setup`
- keep user-provided cross-compilers and detect defaults in `scripts/build_arm.sh`
- document expected cross compiler prefixes

## Testing
- `cargo test` *(fails: lock file version 4 requires -Znext-lockfile-bump)*
- `SETUP_CONFIG_ALL=1 PATH=tmpbin:$PATH ./setup config` with `uname` stubbed to Darwin
- `CROSS_COMPILE_ARM=foo- CROSS_COMPILE_ARM64=bar- PATH=tmpbin:$PATH ./setup config`
- `PATH=tmpbin:$PATH bash scripts/build_arm.sh --no-clean`
- `CROSS_COMPILE_ARM=foo- CROSS_COMPILE_ARM64=bar- PATH=tmpbin:$PATH bash scripts/build_arm.sh --no-clean`

