### PR TITLE
Move and enhance runqemu helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,4 +145,4 @@ These names correspond to capability handles defined in `files/cfg/bash.cfg`.
 
 To extend the system, drop additional unit files into `files/systemd`, declare any required capability mappings in their `Environment` sections, and enable them via symlink or `systemctl enable`.
 
-For debugging during boot, you can pass standard systemd options such as `systemd.log_level=debug` or `systemd.debug-shell` on the kernel command line (edit `files/cfg/bash.cfg` accordingly) and use the QEMU console launched by `runqemu.sh` with tools like `journalctl` or `systemctl status`.
+For debugging during boot, you can pass standard systemd options such as `systemd.log_level=debug` or `systemd.debug-shell` on the kernel command line (edit `files/cfg/bash.cfg` accordingly) and use the QEMU console launched by `scripts/runqemu.sh [IMAGE]` with tools like `journalctl` or `systemctl status`.

--- a/runqemu.sh
+++ b/runqemu.sh
@@ -1,1 +1,0 @@
-./src/l4/tool/bin/l4image -i obj/l4/arm64/images/bootstrap_systemd_arm_virt.elf launch

--- a/scripts/runqemu.sh
+++ b/scripts/runqemu.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+REPO_ROOT="$SCRIPT_DIR/.."
+
+IMAGE_PATH="${1:-$REPO_ROOT/obj/l4/arm64/images/bootstrap_systemd_arm_virt.elf}"
+"$REPO_ROOT/src/l4/tool/bin/l4image" -i "$IMAGE_PATH" launch


### PR DESCRIPTION
## Summary
- move runqemu helper under scripts/
- add shebang, strict mode, and optional image path
- update documentation for new location

## Testing
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*
- `shellcheck scripts/runqemu.sh`
