### PR TITLE
Prefer aarch64-elf cross compiler on macOS

### DIFF
--- a/scripts/common_build.sh
+++ b/scripts/common_build.sh
@@ -17,18 +17,22 @@ detect_cross_compilers() {
       fi
 
       if [ -z "${CROSS_COMPILE_ARM64:-}" ]; then
-        if command -v aarch64-linux-gnu-gcc >/dev/null 2>&1; then
+        if command -v aarch64-elf-gcc >/dev/null 2>&1; then
+          CROSS_COMPILE_ARM64=aarch64-elf-
+        elif command -v aarch64-none-elf-gcc >/dev/null 2>&1; then
+          CROSS_COMPILE_ARM64=aarch64-none-elf-
+        elif command -v aarch64-linux-gnu-gcc >/dev/null 2>&1; then
           CROSS_COMPILE_ARM64=aarch64-linux-gnu-
         elif command -v aarch64-unknown-linux-gnu-gcc >/dev/null 2>&1; then
           CROSS_COMPILE_ARM64=aarch64-unknown-linux-gnu-
         else
-          echo "No AArch64 cross compiler found. Please install aarch64-linux-gnu-gcc or aarch64-unknown-linux-gnu-gcc." >&2
+          echo "No AArch64 cross compiler found. Please install aarch64-elf-gcc (preferred), aarch64-none-elf-gcc, aarch64-linux-gnu-gcc, or aarch64-unknown-linux-gnu-gcc." >&2
           exit 1
         fi
       fi
 
-      if [[ ${CROSS_COMPILE_ARM64} != *linux* ]]; then
-        echo "No Linux-targeted AArch64 cross compiler found (expected aarch64-linux-gnu- or aarch64-unknown-linux-gnu-)." >&2
+      if [[ ${CROSS_COMPILE_ARM64} != *elf* && ${CROSS_COMPILE_ARM64} != *linux* ]]; then
+        echo "No ELF- or Linux-targeted AArch64 cross compiler found (expected aarch64-elf-, aarch64-none-elf-, aarch64-linux-gnu-, or aarch64-unknown-linux-gnu-)." >&2
         exit 1
       fi
 


### PR DESCRIPTION
## Summary
- Prefer bare-metal AArch64 toolchains on macOS by probing `aarch64-elf-gcc` or `aarch64-none-elf-gcc` before falling back to Linux-targeted compilers
- Mention `aarch64-elf-gcc` as the primary requirement in missing compiler error messages
- Accept both ELF- and Linux-targeted prefixes when validating the chosen AArch64 cross compiler

## Testing
- `bash -n scripts/common_build.sh`
- `shellcheck scripts/common_build.sh`

