### PR TITLE
Prefer aarch64-elf toolchain on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ they can be installed via your distribution, Homebrew, or built with
 [crosstool-ng](https://crosstool-ng.github.io/).
 
 If `setup` or `scripts/build.sh` report a failure such as
-`Required tool aarch64-none-elf-gcc not found`, a Linux-targeted AArch64
-toolchain is missing. Install one with your package manager, e.g.
-`sudo apt install gcc-aarch64-linux-gnu` or `brew install aarch64-linux-gnu-gcc`,
-and export `CROSS_COMPILE_ARM64=aarch64-linux-gnu-`.
+`Required tool aarch64-elf-gcc not found`, an AArch64 cross compiler is
+missing. Install one with your package manager, e.g.
+`brew install aarch64-elf-gcc` or `sudo apt install gcc-aarch64-linux-gnu`,
+and export the appropriate prefix (`CROSS_COMPILE_ARM64=aarch64-elf-` or
+`aarch64-linux-gnu-`).
 
 After installing a toolchain, add its `bin` directory to your `PATH` and set
 the expected prefixes:
@@ -54,10 +55,10 @@ the expected prefixes:
 ```bash
 export PATH=/path/to/toolchain/bin:$PATH
 export CROSS_COMPILE_ARM=arm-linux-gnueabihf-
-export CROSS_COMPILE_ARM64=aarch64-linux-gnu-
+export CROSS_COMPILE_ARM64=aarch64-elf-
 ```
 
-Verify the compiler is on your `PATH` (e.g., `aarch64-linux-gnu-gcc --version`)
+Verify the compiler is on your `PATH` (e.g., `aarch64-elf-gcc --version`)
 before invoking `scripts/build.sh` or `setup`.
 
 When these variables are unset, the scripts attempt to choose sensible
@@ -74,16 +75,16 @@ compilers:
 
 ```bash
 brew install qemu e2fsprogs coreutils meson ninja pkg-config
-brew install arm-linux-gnueabihf-gcc aarch64-linux-gnu-gcc
+brew install arm-linux-gnueabihf-gcc aarch64-elf-gcc
 ```
 
 Ensure the Homebrew prefixes are in your `PATH` and define the compiler
 prefixes expected by the build scripts:
 
 ```bash
-export PATH="$(brew --prefix e2fsprogs)/bin:$(brew --prefix arm-linux-gnueabihf-gcc)/bin:$(brew --prefix aarch64-linux-gnu-gcc)/bin:$PATH"
+export PATH="$(brew --prefix e2fsprogs)/bin:$(brew --prefix arm-linux-gnueabihf-gcc)/bin:$(brew --prefix aarch64-elf-gcc)/bin:$PATH"
 export CROSS_COMPILE_ARM=arm-linux-gnueabihf-
-export CROSS_COMPILE_ARM64=aarch64-linux-gnu-
+export CROSS_COMPILE_ARM64=aarch64-elf-
 ```
 
 macOS does not ship GNU `timeout` or several other GNU utilities required by
@@ -99,7 +100,7 @@ With the environment set up, a smoke test of the build can be run with:
 
 ```bash
 CROSS_COMPILE_ARM=arm-linux-gnueabihf- \
-CROSS_COMPILE_ARM64=aarch64-linux-gnu- \
+CROSS_COMPILE_ARM64=aarch64-elf- \
 scripts/build.sh --test
 ```
 

--- a/setup
+++ b/setup
@@ -118,12 +118,14 @@ do_config()
     Darwin)
       CROSS_COMPILE_ARM=${CROSS_COMPILE_ARM:-arm-none-eabi-}
       if [ -z "${CROSS_COMPILE_ARM64:-}" ]; then
-        if command -v aarch64-linux-gnu-gcc >/dev/null 2>&1; then
+        if command -v aarch64-elf-gcc >/dev/null 2>&1; then
+          CROSS_COMPILE_ARM64=aarch64-elf-
+        elif command -v aarch64-linux-gnu-gcc >/dev/null 2>&1; then
           CROSS_COMPILE_ARM64=aarch64-linux-gnu-
         elif command -v aarch64-unknown-linux-gnu-gcc >/dev/null 2>&1; then
           CROSS_COMPILE_ARM64=aarch64-unknown-linux-gnu-
         else
-          echo "No AArch64 cross compiler found. Please install aarch64-linux-gnu-gcc or aarch64-unknown-linux-gnu-gcc." >&2
+          echo "No AArch64 cross compiler found. Please install aarch64-elf-gcc (preferred), aarch64-linux-gnu-gcc, or aarch64-unknown-linux-gnu-gcc." >&2
           exit 1
         fi
       fi
@@ -300,7 +302,7 @@ do_config()
 
     if [ -n "$CONF_DO_ARM64" ]; then
       dialog --no-mouse --visit-items \
-	--inputbox "AARCH64 cross compiler prefix (CROSS_COMPILE)" 8 70 "aarch64-linux-gnu-" \
+	--inputbox "AARCH64 cross compiler prefix (CROSS_COMPILE)" 8 70 "aarch64-elf-" \
 	2> $tmpfile
       CROSS_COMPILE_ARM64=$(cat $tmpfile)
     fi


### PR DESCRIPTION
## Summary
- favor bare-metal `aarch64-elf-gcc` for macOS builds
- default interactive AArch64 compiler prompt to `aarch64-elf-`
- document `aarch64-elf-gcc` as the expected AArch64 toolchain

## Testing
- `shellcheck setup`
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_e_68c649d980c4832fa9a1e2b208f3c822