### PR TITLE
docs: update macOS cross-compilation toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,17 @@ the freshly built static libc.
 Both the `setup` script and `scripts/build.sh` look for compiler prefixes
 via the `CROSS_COMPILE_ARM` and `CROSS_COMPILE_ARM64` environment variables.
 Typical prefixes for Linux-targeted toolchains are `arm-linux-gnueabihf-` and
-`aarch64-linux-gnu-`.  If these cross-compilers are not already available,
-they can be installed via your distribution, Homebrew, or built with
+`aarch64-linux-gnu-`, while macOS now uses the `aarch64-elf-` prefix by default.
+If these cross-compilers are not already available, they can be installed via
+your distribution, Homebrew, or built with
 [crosstool-ng](https://crosstool-ng.github.io/).
 
 If `setup` or `scripts/build.sh` report a failure such as
 `Required tool aarch64-elf-gcc not found`, an AArch64 cross compiler is
 missing. Install one with your package manager, e.g.
-`brew install aarch64-elf-gcc` or `sudo apt install gcc-aarch64-linux-gnu`,
-and export the appropriate prefix (`CROSS_COMPILE_ARM64=aarch64-elf-` or
-`aarch64-linux-gnu-`).
+`brew install aarch64-elf-gcc` or, on Linux hosts, `sudo apt install
+gcc-aarch64-linux-gnu`, and export the appropriate prefix (`CROSS_COMPILE_ARM64=aarch64-elf-`
+or `aarch64-linux-gnu-`).
 
 After installing a toolchain, add its `bin` directory to your `PATH` and set
 the expected prefixes:

--- a/scripts/common_build.sh
+++ b/scripts/common_build.sh
@@ -26,13 +26,13 @@ detect_cross_compilers() {
         elif command -v aarch64-unknown-linux-gnu-gcc >/dev/null 2>&1; then
           CROSS_COMPILE_ARM64=aarch64-unknown-linux-gnu-
         else
-          echo "No AArch64 cross compiler found. Please install aarch64-elf-gcc (preferred), aarch64-none-elf-gcc, aarch64-linux-gnu-gcc, or aarch64-unknown-linux-gnu-gcc." >&2
+          echo "No AArch64 cross compiler found. Please install aarch64-elf-gcc (preferred; Linux hosts may use aarch64-linux-gnu-gcc or aarch64-unknown-linux-gnu-gcc)." >&2
           exit 1
         fi
       fi
 
       if [[ ${CROSS_COMPILE_ARM64} != *elf* && ${CROSS_COMPILE_ARM64} != *linux* ]]; then
-        echo "No ELF- or Linux-targeted AArch64 cross compiler found (expected aarch64-elf-, aarch64-none-elf-, aarch64-linux-gnu-, or aarch64-unknown-linux-gnu-)." >&2
+        echo "No ELF- or Linux-targeted AArch64 cross compiler found (expected aarch64-elf- (macOS), aarch64-none-elf-, aarch64-linux-gnu-, or aarch64-unknown-linux-gnu-)." >&2
         exit 1
       fi
 

--- a/setup
+++ b/setup
@@ -125,7 +125,7 @@ do_config()
         elif command -v aarch64-unknown-linux-gnu-gcc >/dev/null 2>&1; then
           CROSS_COMPILE_ARM64=aarch64-unknown-linux-gnu-
         else
-          echo "No AArch64 cross compiler found. Please install aarch64-elf-gcc (preferred), aarch64-linux-gnu-gcc, or aarch64-unknown-linux-gnu-gcc." >&2
+          echo "No AArch64 cross compiler found. Please install aarch64-elf-gcc (preferred; Linux hosts may use aarch64-linux-gnu-gcc or aarch64-unknown-linux-gnu-gcc)." >&2
           exit 1
         fi
       fi


### PR DESCRIPTION
## Summary
- document that macOS defaults to the aarch64-elf-gcc cross toolchain
- update macOS installation and environment variable examples
- clarify build script messaging around aarch64 cross compilers

## Testing
- `cargo fmt --all`
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*
