### PR TITLE
Add Docker build environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential \
+        gcc-arm-linux-gnueabihf \
+        gcc-aarch64-linux-gnu \
+        qemu \
+        e2fsprogs \
+        meson \
+        ninja-build \
+        pkg-config \
+        git \
+        curl \
+        python3 \
+        openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CROSS_COMPILE_ARM=arm-linux-gnueabihf-
+ENV CROSS_COMPILE_ARM64=aarch64-linux-gnu-
+
+WORKDIR /workspace
+
+ENTRYPOINT ["scripts/build.sh"]


### PR DESCRIPTION
## Summary
- add Dockerfile for cross-compiling L4Re with ARM and AArch64 toolchains

## Testing
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*
