### PR TITLE
Add Docker build wrapper

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+IMAGE="l4rerust-builder"
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  docker build -t "$IMAGE" docker/
+fi
+
+docker run --rm -v "$PWD:/workspace" -w /workspace "$IMAGE" scripts/build.sh "$@"


### PR DESCRIPTION
## Summary
- add `scripts/docker_build.sh` to build/run using docker

## Testing
- `cargo test` *(fails: linux_shims requires nightly features)*
- `scripts/docker_build.sh --test` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68c64d983d80832fbe357d7452c3d523