### PR TITLE
Add docker build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,12 @@ pre-built-images/l4image:
 	@echo Creating $@
 	@src/l4/tool/bin/l4image --create-l4image-binary $@
 
+docker-build:
+	@scripts/docker_build.sh $(filter-out $@,$(MAKECMDGOALS))
+
+%:
+	@:
+
 help:
 	@echo "Targets:"
 	@echo "  all"
@@ -170,7 +176,8 @@ help:
 	@echo "  bash-image    Build image with Bash as first program"
 	@echo "  systemd-image Build image with systemd"
 	@echo "  examples      Build Rust example servers and clients"
+	@echo "  docker-build  Build project inside Docker container"
 
-.PHONY: setup all build_all clean help \
+.PHONY: setup all build_all clean help docker-build \
 build_images build_fiasco build_l4re build_l4linux bash-image \
 systemd-image examples


### PR DESCRIPTION
## Summary
- Add `docker-build` target to wrap `scripts/docker_build.sh` and forward extra arguments
- Document new `docker-build` target in `make help`
- Add catch-all pattern rule to pass additional flags to `docker-build`

## Testing
- `make help`
- `make docker-build test` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68c64e6069e4832fb040b75398339004