### PR TITLE
Add .dockerignore for build artifacts and temp dirs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts and temporary directories
+/target
+**/target/
+obj/
+**/obj/
+out/
+**/out/
+*.tar.gz
+


### PR DESCRIPTION
## Summary
- ignore build outputs and temporary artifacts in Docker context

## Testing
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*
