### PR TITLE
Include build scripts in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,5 +20,6 @@ ENV CROSS_COMPILE_ARM=arm-linux-gnueabihf-
 ENV CROSS_COMPILE_ARM64=aarch64-linux-gnu-
 
 WORKDIR /workspace
+COPY scripts/ /workspace/scripts/
 
-ENTRYPOINT ["scripts/build.sh"]
+ENTRYPOINT ["/workspace/scripts/build.sh"]


### PR DESCRIPTION
## Summary
- Copy repository build scripts into the Docker image
- Set entrypoint to the copied build script to avoid host dependency

## Testing
- `docker build -f docker/Dockerfile .` *(fails: Cannot connect to the Docker daemon)*
