### PR TITLE
Simplify docker build invocation

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -11,4 +11,4 @@ if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
   docker build -t "$IMAGE" docker/
 fi
 
-docker run --rm -v "$PWD:/workspace" -w /workspace "$IMAGE" scripts/build.sh "$@"
+docker run --rm -v "$PWD:/workspace" -w /workspace "$IMAGE" "$@"


### PR DESCRIPTION
## Summary
- rely on Dockerfile entrypoint in `docker_build.sh`

## Testing
- `./scripts/docker_build.sh --test` *(fails: ./scripts/docker_build.sh: line 11: docker: command not found)*
