### PR TITLE
Install Perl Git::Repository in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,10 @@ RUN apt-get update && \
         curl \
         python3 \
         openssh-client \
+        perl \
+        cpanminus \
+        libgit-repository-perl \
+    && cpanm --notest Git::Repository \
     && rm -rf /var/lib/apt/lists/*
 
 ENV CROSS_COMPILE_ARM=arm-linux-gnueabihf-


### PR DESCRIPTION
## Summary
- add perl, cpanminus, and libgit-repository-perl packages
- install Perl Git::Repository module via cpanm during build

## Testing
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*
- `docker build -t l4rerust-test docker` *(fails: Cannot connect to the Docker daemon)*
- `podman build -t l4rerust-test docker` *(fails: Forbidden downloading base image)*
