### PR TITLE
Add entry and exit logging to build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo "Entering build container"
+trap 'echo "Leaving build container"' EXIT
+
 SCRIPT_DIR="$(dirname "$0")"
 # shellcheck source=common_build.sh
 source "$SCRIPT_DIR/common_build.sh"


### PR DESCRIPTION
## Summary
- log entering and exiting the build container via messages and an EXIT trap

## Testing
- `shellcheck scripts/build.sh`
- `./scripts/build.sh --invalid`
- ❌ `./scripts/docker_build.sh ./scripts/build.sh --invalid` (command not found)

