### PR TITLE
Install Git::Repository via cpanm in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && \
         openssh-client \
         perl \
         cpanminus \
-        libgit-repository-perl \
     && cpanm --notest Git::Repository \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- ensure Docker image installs cpanminus
- use cpanm to install Perl Git::Repository module

## Testing
- ⚠️ `podman build -t l4re-env -f docker/Dockerfile .` (403 pulling base image)
- ⚠️ `perl -MGit::Repository -e 1` (module unavailable outside container)
