### PR TITLE
Use repo root as Docker build context

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -8,7 +8,7 @@ cd "$REPO_ROOT"
 IMAGE="l4rerust-builder"
 
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-  docker build -t "$IMAGE" docker/
+  docker build -t "$IMAGE" -f docker/Dockerfile .
 fi
 
 docker run --rm -v "$PWD:/workspace" -w /workspace "$IMAGE" "$@"


### PR DESCRIPTION
## Summary
- Build Docker image with repository root as context to ensure scripts/ directory is included.

## Testing
- `cargo test` *(fails: E0554 `#![feature]` may not be used on the stable release channel)*
- `docker version` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
