### PR TITLE
Use named container and copy out build artifacts

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -11,4 +11,25 @@ if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
   docker build -t "$IMAGE" -f docker/Dockerfile .
 fi
 
-docker run --rm -v "$PWD:/workspace" -w /workspace "$IMAGE" "$@"
+# Create a named container so we can copy build artifacts out afterwards.
+container="l4rerust-build-$$"
+
+# Create container without bind mounts to enforce copy-out semantics.
+docker create --name "$container" -w /workspace "$IMAGE" "$@" >/dev/null
+
+# Copy the repository into the container.
+docker cp . "$container:/workspace"
+
+# Run the build and capture the exit status.
+build_status=0
+docker start -a "$container" || build_status=$?
+
+# Copy the generated artifacts back to the host.
+host_out="$REPO_ROOT/out"
+rm -rf "$host_out"
+docker cp "$container:/workspace/out" "$host_out" >/dev/null || true
+
+# Clean up the container regardless of success.
+docker rm "$container" >/dev/null
+
+exit $build_status


### PR DESCRIPTION
## Summary
- rewrite docker_build.sh to run builds in a named container and copy the `out/` directory back to the host

## Testing
- `bash -n scripts/docker_build.sh`
- `shellcheck scripts/docker_build.sh`
