### PR TITLE
chore: update default qemu image path

### DIFF
--- a/scripts/runqemu.sh
+++ b/scripts/runqemu.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 SCRIPT_DIR="$(dirname "$0")"
 REPO_ROOT="$SCRIPT_DIR/.."
 
-IMAGE_PATH="${1:-$REPO_ROOT/obj/l4/arm64/images/bootstrap_systemd_arm_virt.elf}"
+IMAGE_PATH="${1:-$REPO_ROOT/out/images/bootstrap_systemd_arm_virt.elf}"
 "$REPO_ROOT/src/l4/tool/bin/l4image" -i "$IMAGE_PATH" launch


### PR DESCRIPTION
## Summary
- default runqemu to out/images/bootstrap_systemd_arm_virt.elf

## Testing
- `cargo test` *(fails: `error[E0554]: #![feature] may not be used on the stable release channel`)*
