### PR TITLE
Ensure ARM build script creates artifacts directory

### DIFF
--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -32,6 +32,7 @@ detect_cross_compilers
 validate_tools
 
 ARTIFACTS_DIR="out"
+mkdir -p "$ARTIFACTS_DIR"
 
 # Sync manifests using ham
 (


### PR DESCRIPTION
## Summary
- create `out` artifacts directory early in `scripts/build_arm.sh`

## Testing
- `bash -n scripts/build_arm.sh`
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*
