### PR TITLE
Check for build artifacts before copying

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -27,7 +27,11 @@ docker start -a "$container" || build_status=$?
 # Copy the generated artifacts back to the host.
 host_out="$REPO_ROOT/out"
 rm -rf "$host_out"
-docker cp "$container:/workspace/out" "$host_out" >/dev/null || true
+if docker exec "$container" test -d /workspace/out; then
+  docker cp "$container:/workspace/out" "$host_out" >/dev/null || true
+else
+  echo "No build artifacts were generated."
+fi
 
 # Clean up the container regardless of success.
 docker rm "$container" >/dev/null


### PR DESCRIPTION
## Summary
- avoid failing copy when `/workspace/out` is missing

## Testing
- `bash -n scripts/docker_build.sh`
- `cargo test` *(fails: cc-rs: command did not execute successfully; E0554 feature(c_variadic) requires nightly)*
