### PR TITLE
Handle artifact copy failures in docker build script

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -28,7 +28,9 @@ docker start -a "$container" || build_status=$?
 host_out="$REPO_ROOT/out"
 rm -rf "$host_out"
 if docker exec "$container" test -d /workspace/out; then
-  docker cp "$container:/workspace/out" "$host_out" >/dev/null || true
+  if ! docker cp "$container:/workspace/out" "$host_out" >/dev/null; then
+    echo "Failed to copy build artifacts."
+  fi
 else
   echo "No build artifacts were generated."
 fi


### PR DESCRIPTION
## Summary
- remove no-op `|| true` from docker artifact copy step
- echo a message when copying artifacts fails while still exiting with build status

## Testing
- `bash -n scripts/docker_build.sh`
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_e_68c667491cd8832f8a671629f1d82026