### PR TITLE
Centralize cross-compiler detection

### DIFF
--- a/setup
+++ b/setup
@@ -4,6 +4,11 @@
 
 set -e
 
+# Source shared build helpers.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/common_build.sh
+source "$SCRIPT_DIR/scripts/common_build.sh"
+
 # check we're in the right directory
 if [ ! -d src/l4 -o ! -d src/fiasco ]; then
   echo "Call setup as ./$(basename $0) in the right directory"
@@ -114,27 +119,7 @@ do_config()
     #CONF_DO_MIPS64R2=1
     #CONF_DO_MIPS64R6=1
 
-    case "$(uname -s)" in
-    Darwin)
-      CROSS_COMPILE_ARM=${CROSS_COMPILE_ARM:-arm-none-eabi-}
-      if [ -z "${CROSS_COMPILE_ARM64:-}" ]; then
-        if command -v aarch64-elf-gcc >/dev/null 2>&1; then
-          CROSS_COMPILE_ARM64=aarch64-elf-
-        elif command -v aarch64-linux-gnu-gcc >/dev/null 2>&1; then
-          CROSS_COMPILE_ARM64=aarch64-linux-gnu-
-        elif command -v aarch64-unknown-linux-gnu-gcc >/dev/null 2>&1; then
-          CROSS_COMPILE_ARM64=aarch64-unknown-linux-gnu-
-        else
-          echo "No AArch64 cross compiler found. Please install aarch64-elf-gcc (preferred; Linux hosts may use aarch64-linux-gnu-gcc or aarch64-unknown-linux-gnu-gcc)." >&2
-          exit 1
-        fi
-      fi
-      ;;
-    *)
-      CROSS_COMPILE_ARM=${CROSS_COMPILE_ARM:-arm-linux-gnueabihf-}
-      CROSS_COMPILE_ARM64=${CROSS_COMPILE_ARM64:-aarch64-linux-gnu-}
-      ;;
-    esac
+    detect_cross_compilers
     CROSS_COMPILE_MIPS32R2=${CROSS_COMPILE_MIPS32R2:-mips-linux-}
     CROSS_COMPILE_MIPS32R6=${CROSS_COMPILE_MIPS32R6:-mips-linux-}
     CROSS_COMPILE_MIPS64R2=${CROSS_COMPILE_MIPS64R2:-mips-linux-}


### PR DESCRIPTION
## Summary
- Source common build utilities in `setup`.
- Reuse `detect_cross_compilers` instead of inlined cross-compiler case logic.

## Testing
- `shellcheck setup scripts/common_build.sh scripts/build.sh scripts/build_arm.sh`
- `bash -n setup scripts/common_build.sh scripts/build.sh scripts/build_arm.sh`

