### PR TITLE
Document workspace volume mapping and helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ docker image rm l4rerust-builder
 ## Containerized build
 Instructions for building inside a Docker container are available in [docs/build.md](docs/build.md).
 
+### Mounted workspace
+
+To work with a persistent workspace inside the container, create a directory on
+the host and mount it at `/workspace`:
+
+```bash
+mkdir -p /path/to/host-workspace
+docker run --rm -it -v /path/to/host-workspace:/workspace l4rerust-builder
+```
+
+Inside the container the repository will appear under `/workspace`, which can be
+verified with:
+
+```bash
+ls /workspace
+```
+
+The [`scripts/docker_run.sh`](scripts/docker_run.sh) helper wraps this command
+and accepts additional arguments to pass to `docker run`.
+
 ## Building for ARM
 Steps for building the project for ARM targets are documented in [docs/build.md](docs/build.md).
 

--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+docker run --rm -it -v "${REPO_ROOT}:/workspace" -w /workspace l4rerust-builder "$@"
+


### PR DESCRIPTION
## Summary
- explain how to mount a host workspace into the container and verify the mount
- add a docker_run helper script for invoking the container with the workspace volume

## Testing
- `cargo check --workspace --exclude driver` *(fails: feature may not be used on the stable release channel)*
