### PR TITLE
Add clean subcommand for build cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all:
 	fi
 
 clean:
-	@$(RM) -r obj
+	@./setup clean
 
 setup:
 	@if [ -d obj ]; then                                                            \

--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -32,7 +32,6 @@ detect_cross_compilers
 validate_tools
 
 ARTIFACTS_DIR="out"
-mkdir -p "$ARTIFACTS_DIR"
 
 # Ensure the ham build tool is available
 HAM_PATH="$(realpath "$SCRIPT_DIR/../ham")"
@@ -60,13 +59,10 @@ fi
 
 # Start from a clean state
 if [ "$clean" = true ]; then
-  # Remove common build directories if they exist
-  for dir in obj "$ARTIFACTS_DIR"; do
-    if [ -d "$dir" ]; then
-      rm -rf "$dir"
-    fi
-  done
+  ./setup clean
 fi
+
+mkdir -p "$ARTIFACTS_DIR"
 
 # Configure for ARM using setup script
 export CROSS_COMPILE_ARM CROSS_COMPILE_ARM64

--- a/setup
+++ b/setup
@@ -9,8 +9,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=scripts/common_build.sh
 source "$SCRIPT_DIR/scripts/common_build.sh"
 
-# check we're in the right directory
-if [ ! -d src/l4 -o ! -d src/fiasco ]; then
+# check we're in the right directory when needed
+if [ "$1" != "clean" ] && [ ! -d src/l4 -o ! -d src/fiasco ]; then
   echo "Call setup as ./$(basename $0) in the right directory"
   exit 1
 fi
@@ -20,17 +20,19 @@ if [ -n "$SYSTEM" ]; then
   exit 1
 fi
 
-if [ -n "$CROSS_COMPILE" ]; then
-  read -p "Cross-compiler prefix (CROSS_COMPILE) [$CROSS_COMPILE]: " tmp
-  CROSS_COMPILE=${tmp:-$CROSS_COMPILE}
-else
-  read -p "Cross-compiler prefix (CROSS_COMPILE): " CROSS_COMPILE
-fi
-export CROSS_COMPILE
+if [ "$1" != "clean" ]; then
+  if [ -n "$CROSS_COMPILE" ]; then
+    read -p "Cross-compiler prefix (CROSS_COMPILE) [$CROSS_COMPILE]: " tmp
+    CROSS_COMPILE=${tmp:-$CROSS_COMPILE}
+  else
+    read -p "Cross-compiler prefix (CROSS_COMPILE): " CROSS_COMPILE
+  fi
+  export CROSS_COMPILE
 
-CC=${CC:-${CROSS_COMPILE}gcc}
-CXX=${CXX:-${CROSS_COMPILE}g++}
-LD=${LD:-${CROSS_COMPILE}ld}
+  CC=${CC:-${CROSS_COMPILE}gcc}
+  CXX=${CXX:-${CROSS_COMPILE}g++}
+  LD=${LD:-${CROSS_COMPILE}ld}
+fi
 
 add_to_config()
 {
@@ -1011,8 +1013,12 @@ case "$1" in
      redo_config
      do_setup
      ;;
+  clean)
+     do_clean
+     rm -rf out
+     ;;
   *)
-     echo "Call $0 [config|setup]"
+     echo "Call $0 [config|setup|clean]"
      exit 1
      ;;
 esac


### PR DESCRIPTION
## Summary
- add a `clean` subcommand to `setup` that removes `obj` and `out`
- route Makefile `clean` target through `./setup clean`
- use `./setup clean` in `scripts/build_arm.sh` instead of manual directory removal

## Testing
- `bash -n setup`
- `bash -n scripts/build_arm.sh`
- `make clean`

