### PR TITLE
Add non-interactive setup mode and update ARM build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ a containerized build environment, and workflows for packaging and deployment.
 ## Quick Start
 1. Install toolchains and prerequisites: see [docs/toolchains.md](docs/toolchains.md).
 2. Obtain the `ham` build tool: see [Installing ham](#installing-ham).
-3. Build the project or container: follow [docs/build.md](docs/build.md).
+3. Configure the snapshot: run `./setup --non-interactive` to generate
+   default configuration files. The script performs both the `config` and
+   `setup` phases without prompting.
+4. Build the project or container: follow [docs/build.md](docs/build.md).
    For ARM targets, use the ARM section in that document.
-4. Package drivers using [docs/driver-packaging.md](docs/driver-packaging.md).
-5. Integrate systemd services as described in [docs/systemd.md](docs/systemd.md).
+5. Package drivers using [docs/driver-packaging.md](docs/driver-packaging.md).
+6. Integrate systemd services as described in [docs/systemd.md](docs/systemd.md).
 
 ## Installing ham
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -6,6 +6,20 @@ the repository root before invoking any build commands. See the [Installing
 ham](../README.md#installing-ham) section in the repository root for setup
 instructions.
 
+## Repository setup
+
+Before running any of the build scripts, the L4Re snapshot must be configured.
+The setup script now provides a unified, non-interactive entry point which
+performs both the configuration and setup phases in a single call:
+
+```bash
+./setup --non-interactive
+```
+
+This generates the necessary configuration files and Makefiles using sensible
+defaults. The traditional interactive invocation (`./setup config` followed by
+`./setup setup` or `make setup`) remains available for manual configuration.
+
 ## Containerized build
 
 If cross-compilers or required GNU utilities are not available on the host,

--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -66,7 +66,8 @@ mkdir -p "$ARTIFACTS_DIR"
 
 # Configure for ARM using setup script
 export CROSS_COMPILE_ARM CROSS_COMPILE_ARM64
-SETUP_CONFIG_ALL=1 ./setup config
+# Run the full non-interactive setup to generate configuration and makefiles
+./setup --non-interactive
 
 # Build the Rust libc crate so other crates can link against it
 (

--- a/setup
+++ b/setup
@@ -9,8 +9,18 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=scripts/common_build.sh
 source "$SCRIPT_DIR/scripts/common_build.sh"
 
+# Handle optional non-interactive mode which runs both config and setup in
+# one go. When invoked as `./setup --non-interactive` the script will skip
+# prompts and execute the combined steps automatically.
+cmd="$1"
+non_interactive=0
+if [ "$cmd" = "--non-interactive" ]; then
+  non_interactive=1
+  cmd="all"
+fi
+
 # check we're in the right directory when needed
-if [ "$1" != "clean" ] && [ ! -d src/l4 -o ! -d src/fiasco ]; then
+if [ "$cmd" != "clean" ] && [ ! -d src/l4 -o ! -d src/fiasco ]; then
   echo "Call setup as ./$(basename $0) in the right directory"
   exit 1
 fi
@@ -20,19 +30,19 @@ if [ -n "$SYSTEM" ]; then
   exit 1
 fi
 
-if [ "$1" != "clean" ]; then
+if [ "$cmd" != "clean" ] && [ "$non_interactive" -eq 0 ]; then
   if [ -n "$CROSS_COMPILE" ]; then
     read -p "Cross-compiler prefix (CROSS_COMPILE) [$CROSS_COMPILE]: " tmp
     CROSS_COMPILE=${tmp:-$CROSS_COMPILE}
   else
     read -p "Cross-compiler prefix (CROSS_COMPILE): " CROSS_COMPILE
   fi
-  export CROSS_COMPILE
-
-  CC=${CC:-${CROSS_COMPILE}gcc}
-  CXX=${CXX:-${CROSS_COMPILE}g++}
-  LD=${LD:-${CROSS_COMPILE}ld}
 fi
+
+export CROSS_COMPILE=${CROSS_COMPILE:-}
+CC=${CC:-${CROSS_COMPILE}gcc}
+CXX=${CXX:-${CROSS_COMPILE}g++}
+LD=${LD:-${CROSS_COMPILE}ld}
 
 add_to_config()
 {
@@ -1003,11 +1013,19 @@ EOF
 }
 
 
-case "$1" in
+case "$cmd" in
   config)
      do_config
      ;;
   setup)
+     load_config
+     check_tools
+     redo_config
+     do_setup
+     ;;
+  all)
+     SETUP_CONFIG_ALL=${SETUP_CONFIG_ALL:-1}
+     do_config
      load_config
      check_tools
      redo_config
@@ -1018,7 +1036,7 @@ case "$1" in
      rm -rf out
      ;;
   *)
-     echo "Call $0 [config|setup|clean]"
+     echo "Call $0 [config|setup|clean|--non-interactive]"
      exit 1
      ;;
 esac


### PR DESCRIPTION
## Summary
- add `--non-interactive` mode to `setup` that runs config and setup in one go
- have `scripts/build_arm.sh` use the new unified setup command
- document the new setup entry point for developers

## Testing
- `bash -n setup`
- `bash -n scripts/build_arm.sh`
- `./setup --non-interactive` *(fails: Call setup as ./setup in the right directory)*
- `scripts/build_arm.sh --no-clean` *(fails: Required tool arm-linux-gnueabihf-gcc not found)*
