### PR TITLE
Add workspace mount option to container helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ the host and mount it at `/workspace`:
 
 ```bash
 mkdir -p /path/to/host-workspace
+scripts/docker_run.sh --workspace /path/to/host-workspace
+```
+
+The script resolves the path to an absolute location and forwards any remaining
+arguments to `docker run`. The equivalent manual invocation is:
+
+```bash
 docker run --rm -it -v /path/to/host-workspace:/workspace l4rerust-builder
 ```
 
@@ -85,8 +92,29 @@ verified with:
 ls /workspace
 ```
 
-The [`scripts/docker_run.sh`](scripts/docker_run.sh) helper wraps this command
-and accepts additional arguments to pass to `docker run`.
+#### Automatic startup
+
+To launch the container automatically, define a shell alias:
+
+```bash
+alias l4re='~/l4rerust/scripts/docker_run.sh --workspace ~/l4re-workspace'
+```
+
+Or create a user systemd service:
+
+```ini
+# ~/.config/systemd/user/l4rerust.service
+[Unit]
+Description=L4ReRust development container
+
+[Service]
+ExecStart=/path/to/repo/scripts/docker_run.sh --workspace /path/to/host-workspace
+
+[Install]
+WantedBy=default.target
+```
+
+Enable it with `systemctl --user enable --now l4rerust.service`.
 
 ## Building for ARM
 Steps for building the project for ARM targets are documented in [docs/build.md](docs/build.md).

--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -4,5 +4,34 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
-docker run --rm -it -v "${REPO_ROOT}:/workspace" -w /workspace l4rerust-builder "$@"
+HOST_WORKSPACE="${REPO_ROOT}"
+DOCKER_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --workspace)
+            shift
+            HOST_WORKSPACE="${1:?--workspace requires a path}"
+            shift
+            ;;
+        -h|--help)
+            cat <<'EOF'
+Usage: docker_run.sh [--workspace PATH] [docker run args...]
+
+Options:
+  --workspace PATH  Host directory to mount at /workspace inside the container.
+                    Defaults to the repository root.
+EOF
+            exit 0
+            ;;
+        *)
+            DOCKER_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+HOST_WORKSPACE="$(realpath "${HOST_WORKSPACE}")"
+
+docker run --rm -it -v "${HOST_WORKSPACE}:/workspace" -w /workspace l4rerust-builder "${DOCKER_ARGS[@]}"
 


### PR DESCRIPTION
## Summary
- extend `scripts/docker_run.sh` to accept a `--workspace` flag and resolve the directory to an absolute path
- document how to mount an external workspace and auto-start the container via alias or systemd

## Testing
- `shellcheck scripts/docker_run.sh` *(fails: command not found)*
- `cargo test` *(fails: `linux_shims` requires nightly features)*

------
https://chatgpt.com/codex/tasks/task_e_68c68e37afd4832f8f30de37d55105a3