### PR TITLE
Add l4re-libc crate to workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "l4re-libc"
+version = "0.1.0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["driver_picker", "src/linux_shims", "src/driver", "src/virtio_frontend"]
+members = ["driver_picker", "src/linux_shims", "src/driver", "src/virtio_frontend", "src/l4rust/l4re-libc"]


### PR DESCRIPTION
## Summary
- add l4re-libc to Cargo workspace

## Testing
- `cargo metadata --no-deps --format-version 1 | jq '.packages[].name'`
- `cargo build -p l4re-libc`


------
https://chatgpt.com/codex/tasks/task_e_68c6b00c4028832f9261aee9c1e5f069