### PR TITLE
Add l4re-core update helper and integrate into build scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,6 +8,9 @@ SCRIPT_DIR="$(dirname "$0")"
 # shellcheck source=common_build.sh
 source "$SCRIPT_DIR/common_build.sh"
 
+# Ensure l4re-core is present and up to date
+"$SCRIPT_DIR/update_l4re_core.sh"
+
 detect_cross_compilers
 validate_tools
 

--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -28,6 +28,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 
+# Ensure l4re-core is present and up to date
+"$SCRIPT_DIR/update_l4re_core.sh"
+
 detect_cross_compilers
 validate_tools
 

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -5,6 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$REPO_ROOT"
 
+# Ensure l4re-core is present and up to date
+"$SCRIPT_DIR/update_l4re_core.sh"
+
 IMAGE="l4rerust-builder"
 
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then

--- a/scripts/update_l4re_core.sh
+++ b/scripts/update_l4re_core.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+L4RE_CORE_DIR="$REPO_ROOT/src/l4re-core"
+
+if [ ! -d "$L4RE_CORE_DIR/.git" ]; then
+  git clone https://github.com/kernkonzept/l4re-core "$L4RE_CORE_DIR"
+fi
+
+(
+  cd "$L4RE_CORE_DIR"
+  git fetch
+  git checkout origin/master
+)


### PR DESCRIPTION
## Summary
- add script to clone and update l4re-core repository
- invoke the updater from build and docker scripts to ensure current l4re-core

## Testing
- `scripts/update_l4re_core.sh`
- `cargo test` *(fails: command not found)*
- `shellcheck scripts/update_l4re_core.sh scripts/build.sh scripts/build_arm.sh scripts/docker_build.sh` *(fails: command not found)*
