### PR TITLE
Use pre-supplied L4Re config in build script

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -35,6 +35,11 @@ container. It performs cross-compilation only and places resulting artifacts
 under `out/`. All toolchains and GNU utilities are provided by the container,
 so nothing else needs to be installed on the host.
 
+For non-interactive Docker builds, the scripts look for an existing L4Re
+configuration in `/workspace/.config` or `scripts/l4re.config`. If either file
+is present, it is copied to `obj/.config` before running `setup`, allowing
+developers to tailor the build by editing `scripts/l4re.config`.
+
 To boot the built image on your host, run:
 
 ```bash

--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -69,9 +69,22 @@ mkdir -p "$ARTIFACTS_DIR"
 
 # Configure for ARM using setup script
 export CROSS_COMPILE_ARM CROSS_COMPILE_ARM64
-# Run the full non-interactive setup to generate configuration and makefiles
-#./setup config 
-./setup setup 
+# Run the setup tool. If a pre-generated configuration is available, reuse it
+# to avoid the interactive `config` step.
+if [ -f /workspace/.config ]; then
+  echo "Using configuration from /workspace/.config"
+  mkdir -p obj
+  cp /workspace/.config obj/.config
+  ./setup setup
+elif [ -f scripts/l4re.config ]; then
+  echo "Using configuration from scripts/l4re.config"
+  mkdir -p obj
+  cp scripts/l4re.config obj/.config
+  ./setup setup
+else
+  ./setup config
+  ./setup setup
+fi
 ./setup --non-interactive
 
 # Build the Rust libc crate so other crates can link against it


### PR DESCRIPTION
## Summary
- allow build script to reuse configuration from `/workspace/.config` or `scripts/l4re.config`
- document Docker builds using `scripts/l4re.config`

## Testing
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*
- `cargo fmt --all -- --check` *(fails: diff found)*

