### PR TITLE
Use gmake for ham build tool

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ if [ ! -x "$HAM_BIN" ]; then
     git clone https://github.com/kernkonzept/ham.git "$HAM_PATH"
   fi
   if [ ! -x "$HAM_BIN" ]; then
-    (cd "$HAM_PATH" && make >/dev/null 2>&1 || true)
+    (cd "$HAM_PATH" && gmake >/dev/null 2>&1 || true)
   fi
   if [ ! -x "$HAM_BIN" ]; then
     curl -L "https://github.com/kernkonzept/ham/releases/latest/download/ham" -o "$HAM_BIN"

--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -40,7 +40,7 @@ if [ ! -x "$HAM_BIN" ]; then
     git clone https://github.com/kernkonzept/ham.git "$HAM_PATH"
   fi
   if [ ! -x "$HAM_BIN" ]; then
-    (cd "$HAM_PATH" && make >/dev/null 2>&1 || true)
+    (cd "$HAM_PATH" && gmake >/dev/null 2>&1 || true)
   fi
   if [ ! -x "$HAM_BIN" ]; then
     curl -L "https://github.com/kernkonzept/ham/releases/latest/download/ham" -o "$HAM_BIN"

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -17,7 +17,7 @@ if [ ! -x "$HAM_BIN" ]; then
     git clone https://github.com/kernkonzept/ham.git "$HAM_PATH"
   fi
   if [ ! -x "$HAM_BIN" ]; then
-    (cd "$HAM_PATH" && make >/dev/null 2>&1 || true)
+    (cd "$HAM_PATH" && gmake >/dev/null 2>&1 || true)
   fi
   if [ ! -x "$HAM_BIN" ]; then
     curl -L "https://github.com/kernkonzept/ham/releases/latest/download/ham" -o "$HAM_BIN"


### PR DESCRIPTION
## Summary
- use `gmake` to build ham in build scripts

## Testing
- `cargo test` *(fails: error[E0554]: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_e_68c7049e566c832fa86b47ab90aa8062