### PR TITLE
docs: use gmake in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Clone and build `ham` from source:
 
 ```bash
 git clone https://github.com/kernkonzept/ham.git ham
-(cd ham && make)
+(cd ham && gmake)
 ```
 
 Or download a prebuilt binary:

--- a/docs/build.md
+++ b/docs/build.md
@@ -18,7 +18,7 @@ performs both the configuration and setup phases in a single call:
 
 This generates the necessary configuration files and Makefiles using sensible
 defaults. The traditional interactive invocation (`./setup config` followed by
-`./setup setup` or `make setup`) remains available for manual configuration.
+`./setup setup` or `gmake setup`) remains available for manual configuration.
 
 ## Containerized build
 
@@ -68,7 +68,7 @@ cd src/l4rust
 cargo build -p l4re-libc --release
 export LIBRARY_PATH=$(pwd)/target/release:${LIBRARY_PATH}
 cd -
-make
+gmake
 ```
 
 Ensuring `LIBRARY_PATH` is set correctly allows the Rust crates to link against

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -1,6 +1,6 @@
 # Systemd integration
 
-The build scripts can produce a systemd-based image. `scripts/build.sh` fetches and cross-builds systemd for arm and arm64, then installs it together with unit files from `files/systemd` into the root filesystem. The same process can be invoked with `make systemd-image`.
+The build scripts can produce a systemd-based image. `scripts/build.sh` fetches and cross-builds systemd for arm and arm64, then installs it together with unit files from `files/systemd` into the root filesystem. The same process can be invoked with `gmake systemd-image`.
 
 Unit files placed in `files/systemd` are copied to `/lib/systemd/system` at build time. `bash.service` is enabled by default. To enable or disable other services, create or remove the corresponding symlinks under `/etc/systemd/system/<target>.wants/` or run `systemctl enable`/`disable` after boot.
 


### PR DESCRIPTION
## Summary
- switch setup instructions to `gmake` in docs
- reference `gmake systemd-image` for systemd builds
- build ham using `gmake` in README

## Testing
- `cargo test --quiet 2>&1 | tail -n 20` *(fails: `#![feature]` may not be used on the stable release channel)*
