### PR TITLE
Add C IPC syscall wrappers and integrate into build

### DIFF
--- a/src/l4rust/l4-rust/Cargo.toml
+++ b/src/l4rust/l4-rust/Cargo.toml
@@ -3,6 +3,7 @@ name = "l4"
 version = "0.1.0"
 authors = ["Sebastian Humenda <shumenda @ gmx . de>"]
 edition = "2021"
+build = "build.rs"
 
 [lib]
 path = "lib.rs"
@@ -38,3 +39,6 @@ std = []
 scheduler = []
 autosar = ["scheduler"]
 linux_like = ["scheduler"]
+
+[build-dependencies]
+cc = "1.0"

--- a/src/l4rust/l4-rust/Makefile
+++ b/src/l4rust/l4-rust/Makefile
@@ -3,6 +3,7 @@ L4DIR  ?= $(PKGDIR)/../../..
 
 TARGET  		= libl4-rust.rlib
 SRC_RS   		= lib.rs
+SRC_C                   = ipc/syscall.c
 
 DEPENDS_PKGS    = l4sys l4-sys-rust
 REQUIRES_LIBS   = l4sys libl4re-wrapper l4-sys-rust

--- a/src/l4rust/l4-rust/build.rs
+++ b/src/l4rust/l4-rust/build.rs
@@ -1,0 +1,12 @@
+use std::env;
+
+fn main() {
+    let mut build = cc::Build::new();
+    build.file("ipc/syscall.c");
+    if let Ok(include_dirs) = env::var("L4_INCLUDE_DIRS") {
+        for dir in include_dirs.split_whitespace() {
+            build.flag(dir);
+        }
+    }
+    build.compile("l4rust_syscalls");
+}

--- a/src/l4rust/l4-rust/ipc/syscall.c
+++ b/src/l4rust/l4-rust/ipc/syscall.c
@@ -1,0 +1,21 @@
+#include <l4/sys/ipc.h>
+
+l4_msgtag_t l4_ipc_call_wrapper(l4_cap_idx_t dest,
+                                l4_utcb_t *utcb,
+                                l4_msgtag_t tag,
+                                l4_timeout_t timeout)
+{
+    return l4_ipc_call(dest, utcb, tag, timeout);
+}
+
+l4_msgtag_t l4_ipc_receive_wrapper(l4_cap_idx_t object,
+                                   l4_utcb_t *utcb,
+                                   l4_timeout_t timeout)
+{
+    return l4_ipc_receive(object, utcb, timeout);
+}
+
+l4_msgtag_t l4_ipc_sleep_wrapper(l4_timeout_t timeout)
+{
+    return l4_ipc_sleep(timeout);
+}

--- a/src/l4rust/l4-rust/ipc/syscall.rs
+++ b/src/l4rust/l4-rust/ipc/syscall.rs
@@ -1,11 +1,28 @@
 //! All syscalls provided by Fiasco
 
 use crate::{
-    cap::{invalid_cap, Cap, Interface},
+    cap::{Cap, Interface},
     ipc::MsgTag,
     sys::l4_timeout_t,
     utcb::Utcb,
 };
+
+extern "C" {
+    fn l4_ipc_call_wrapper(
+        dest: l4_sys::l4_cap_idx_t,
+        utcb: *mut l4_sys::l4_utcb_t,
+        tag: l4_sys::l4_msgtag_t,
+        timeout: l4_sys::l4_timeout_t,
+    ) -> l4_sys::l4_msgtag_t;
+
+    fn l4_ipc_receive_wrapper(
+        object: l4_sys::l4_cap_idx_t,
+        utcb: *mut l4_sys::l4_utcb_t,
+        timeout: l4_sys::l4_timeout_t,
+    ) -> l4_sys::l4_msgtag_t;
+
+    fn l4_ipc_sleep_wrapper(timeout: l4_sys::l4_timeout_t) -> l4_sys::l4_msgtag_t;
+}
 
 /// Simple IPC Call
 ///
@@ -18,7 +35,7 @@ pub fn call<T: Interface>(
     timeout: l4_timeout_t,
 ) -> MsgTag {
     unsafe {
-        MsgTag::from(l4_sys::l4_ipc_call(
+        MsgTag::from(l4_ipc_call_wrapper(
             dest.raw(),
             utcb.raw,
             tag.raw(),
@@ -29,7 +46,7 @@ pub fn call<T: Interface>(
 
 #[inline(always)]
 pub fn receive<T: Interface>(object: Cap<T>, utcb: &mut Utcb, timeout: l4_timeout_t) -> MsgTag {
-    MsgTag::from(unsafe { l4_sys::l4_ipc_receive(object.raw(), utcb.raw(), timeout) })
+    MsgTag::from(unsafe { l4_ipc_receive_wrapper(object.raw(), utcb.raw, timeout) })
 }
 
 /// Sleep for the specified amount of time.
@@ -37,8 +54,5 @@ pub fn receive<T: Interface>(object: Cap<T>, utcb: &mut Utcb, timeout: l4_timeou
 /// This submits a blocking IPC to an invalid destination with the timeout being the time to sleep.
 #[inline]
 pub fn sleep(timeout: l4_timeout_t) -> MsgTag {
-    // SAFETY: This is currently assumed to be unsafe, ignoring UTCB concurrency.
-    unsafe {
-        receive(invalid_cap(), &mut Utcb::current(), timeout)
-    }
+    unsafe { MsgTag::from(l4_ipc_sleep_wrapper(timeout)) }
 }


### PR DESCRIPTION
## Summary
- add C wrappers for IPC call, receive, and sleep and expose them to Rust
- update Rust IPC interface to use the new wrappers
- integrate C wrappers into Cargo build script and Makefile

## Testing
- `cargo check --manifest-path src/l4rust/l4-rust/Cargo.toml` *(fails: current package believes it's in a workspace when it's not)*

------
https://chatgpt.com/codex/tasks/task_e_68c70e70f97c832f9abe7d26b2ad3684