### PR TITLE
Use DEFCONFIG for gmake invocations in setup script

### DIFF
--- a/setup
+++ b/setup
@@ -619,28 +619,28 @@ do_setup()
 
   # L4Re build dirs with default configs
   [ "$CONF_DO_X86_32" ] \
-    && gmake -C src/l4 DROPSCONF_DEFCONFIG=mk/defconfig/config.x86 B=../../obj/l4/x86
+    && gmake -C src/l4 DEFCONFIG=mk/defconfig/config.x86 B=../../obj/l4/x86
 
   [ "$CONF_DO_AMD64" ] \
-    && gmake -C src/l4 DROPSCONF_DEFCONFIG=mk/defconfig/config.amd64 B=../../obj/l4/amd64
+    && gmake -C src/l4 DEFCONFIG=mk/defconfig/config.amd64 B=../../obj/l4/amd64
 
   if [ "$CONF_DO_ARM" ]; then
     gmake -C src/l4 CROSS_COMPILE=$CROSS_COMPILE_ARM \
-      DROPSCONF_DEFCONFIG=mk/defconfig/config.arm-rv-v7a B=../../obj/l4/arm-v7
+      DEFCONFIG=mk/defconfig/config.arm-rv-v7a B=../../obj/l4/arm-v7
     gmake -C obj/l4/arm-v7 CROSS_COMPILE=$CROSS_COMPILE_ARM oldconfig
     ARM_L4_DIR_FOR_LX_MP=obj/l4/arm-v7
     echo CROSS_COMPILE=$CROSS_COMPILE_ARM >> obj/l4/arm-v7/Makeconf.local
   fi
 
   if [ "$CONF_DO_ARM64" ]; then
-    gmake -C src/l4 CROSS_COMPILE=$CROSS_COMPILE_ARM64 DROPSCONF_DEFCONFIG=mk/defconfig/config.arm64-rv-v8a B=../../obj/l4/arm64
+    gmake -C src/l4 CROSS_COMPILE=$CROSS_COMPILE_ARM64 DEFCONFIG=mk/defconfig/config.arm64-rv-v8a B=../../obj/l4/arm64
   fi
 
   if [ "$CONF_DO_MIPS32R2" ]; then
     cp src/l4/mk/defconfig/config.mips .tmp1
     echo CONFIG_PLATFORM_TYPE_malta=y >> .tmp1
     echo CONFIG_CPU_MIPS_32R2=y >> .tmp1
-    gmake -C src/l4 DROPSCONF_DEFCONFIG=../../.tmp1 \
+    gmake -C src/l4 DEFCONFIG=../../.tmp1 \
       CROSS_COMPILE=$CROSS_COMPILE_MIPS32R2 B=../../obj/l4/mips32r2
     rm .tmp1
     echo CROSS_COMPILE=$CROSS_COMPILE_MIPS32R2 >> obj/l4/mips32r2/Makeconf.local
@@ -649,7 +649,7 @@ do_setup()
     cp src/l4/mk/defconfig/config.mips .tmp1
     echo CONFIG_PLATFORM_TYPE_malta=y >> .tmp1
     echo CONFIG_CPU_MIPS_32R6=y >> .tmp1
-    gmake -C src/l4 DROPSCONF_DEFCONFIG=../../.tmp1 \
+    gmake -C src/l4 DEFCONFIG=../../.tmp1 \
       CROSS_COMPILE=$CROSS_COMPILE_MIPS32R6 B=../../obj/l4/mips32r6
     rm .tmp1
     echo CROSS_COMPILE=$CROSS_COMPILE_MIPS32R6 >> obj/l4/mips32r6/Makeconf.local
@@ -658,7 +658,7 @@ do_setup()
     cp src/l4/mk/defconfig/config.mips .tmp1
     echo CONFIG_PLATFORM_TYPE_malta=y >> .tmp1
     echo CONFIG_CPU_MIPS_64R2=y >> .tmp1
-    gmake -C src/l4 DROPSCONF_DEFCONFIG=../../.tmp1 \
+    gmake -C src/l4 DEFCONFIG=../../.tmp1 \
       CROSS_COMPILE=$CROSS_COMPILE_MIPS64R2 B=../../obj/l4/mips64r2
     rm .tmp1
     echo CROSS_COMPILE=$CROSS_COMPILE_MIPS64R2 >> obj/l4/mips64r2/Makeconf.local
@@ -667,7 +667,7 @@ do_setup()
     cp src/l4/mk/defconfig/config.mips .tmp1
     echo CONFIG_PLATFORM_TYPE_boston=y >> .tmp1
     echo CONFIG_CPU_MIPS_64R6=y >> .tmp1
-    gmake -C src/l4 DROPSCONF_DEFCONFIG=../../.tmp1 \
+    gmake -C src/l4 DEFCONFIG=../../.tmp1 \
       CROSS_COMPILE=$CROSS_COMPILE_MIPS64R6 B=../../obj/l4/mips64r6
     rm .tmp1
     echo CROSS_COMPILE=$CROSS_COMPILE_MIPS64R6 >> obj/l4/mips64r6/Makeconf.local


### PR DESCRIPTION
## Summary
- replace deprecated DROPSCONF_DEFCONFIG variable with DEFCONFIG in the `setup` script so L4Re builds use standard Make variable

## Testing
- `./setup setup` *(with stub tooling)*

