### PR TITLE
Add macOS support to gendep script

### DIFF
--- a/tool/gendep/gendep
+++ b/tool/gendep/gendep
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Dependency generator.
+
+This utility inspects a binary for shared library dependencies.
+It uses platform-specific tools:
+
+- On Linux, `readelf -d` is invoked and `NEEDED` entries are parsed.
+- On macOS (Darwin), `otool -L` is used and `.dylib` entries are collected.
+"""
+import os
+import subprocess
+import sys
+from typing import List
+
+
+def _deps_from_readelf(path: str) -> List[str]:
+    """Collect dependencies for ELF binaries using readelf.
+
+    The dynamic section is scanned for `NEEDED` entries which denote shared
+    libraries required at runtime.
+    """
+    output = subprocess.check_output(["readelf", "-d", path], text=True)
+    deps: List[str] = []
+    for line in output.splitlines():
+        if "Shared library" in line:
+            start = line.find("[")
+            end = line.find("]", start)
+            if start != -1 and end != -1:
+                deps.append(line[start + 1 : end])
+    return deps
+
+
+def _deps_from_otool(path: str) -> List[str]:
+    """Collect dependencies for Mach-O binaries using otool.
+
+    `otool -L` lists libraries the binary depends on. Lines after the first
+    contain library paths followed by version info. We keep entries that end
+    with `.dylib` to match shared libraries on macOS.
+    """
+    output = subprocess.check_output(["otool", "-L", path], text=True)
+    deps: List[str] = []
+    for line in output.splitlines()[1:]:
+        lib = line.strip().split(" ")[0]
+        if lib.endswith(".dylib"):
+            deps.append(os.path.basename(lib))
+    return deps
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <binary>")
+        return 1
+    binary = sys.argv[1]
+    uname = os.uname().sysname
+    if uname == "Darwin":
+        deps = _deps_from_otool(binary)
+    else:
+        deps = _deps_from_readelf(binary)
+    for dep in deps:
+        print(dep)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add cross-platform dependency scanner script `gendep`
- support macOS by invoking `otool -L` and parsing `.dylib` libraries
- retain Linux `readelf -d` logic

## Testing
- `cargo test` (fails: `#![feature]` may not be used on the stable release channel)
