### PR TITLE
Restrict l4-sys-rust to ARM architectures

### DIFF
--- a/src/l4rust/l4-sys-rust/consts.rs
+++ b/src/l4rust/l4-sys-rust/consts.rs
@@ -2,12 +2,8 @@
 use crate::c_api::*;
 
 /// An alias for the corresponding platform enum
-#[cfg(target_arch = "x86_64")]
-pub use crate::c_api::L4_utcb_consts_amd64 as UtcbConsts;
 #[cfg(target_arch = "aarch64")]
 pub use crate::c_api::L4_utcb_consts_arm64 as UtcbConsts;
-#[cfg(target_arch = "x86")]
-pub use L4_utcb_consts_x86 as UtcbConsts;
 
 // redefined constants and enums with (wrongly) generated type
 pub const UTCB_GENERIC_DATA_SIZE: usize = UtcbConsts::L4_UTCB_GENERIC_DATA_SIZE as usize;

--- a/src/l4rust/l4-sys-rust/lib.rs
+++ b/src/l4rust/l4-sys-rust/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+#[cfg(not(any(target_arch = "aarch64", target_arch = "aarch32")))]
+compile_error!("Only ARM architectures are supported.");
+
 #[macro_use]
 mod ipc_ext;
 mod c_api;
@@ -38,23 +41,12 @@ pub fn round_page(address: usize) -> l4_addr_t {
     ((address + L4_PAGESIZE as usize - 1usize) & (L4_PAGEMASK as usize)) as l4_addr_t
 }
 
-pub mod util {
-    #[cfg(target_arch = "x86_64")]
-    pub fn rdtscp() -> u64 {
-        unsafe {
-            let mut _val = 0;
-            core::arch::x86_64::__rdtscp(&mut _val)
-        }
-    }
-}
-
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 pub type L4Umword = u64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 pub type L4Mword = i64;
 
-#[cfg(any(target_arch = "x86", target_arch = "aarch32"))]
+#[cfg(target_arch = "aarch32")]
 pub type L4Umword = u32;
-#[cfg(any(target_arch = "x86", target_arch = "aarch32"))]
+#[cfg(target_arch = "aarch32")]
 pub type L4Mword = i32;
-


### PR DESCRIPTION
## Summary
- drop x86-specific constants and type aliases in l4-sys-rust
- guard library compilation so only ARM targets are allowed

## Testing
- `cargo check --target aarch64-unknown-none` *(fails: current package believes it's in a workspace when it's not)*

------
https://chatgpt.com/codex/tasks/task_e_68c719824eb4832fbf69df7560a80f14