### PR TITLE
docs: remove x86_64 toolchain references

### DIFF
--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -3,10 +3,9 @@
 ## Cross-compilation toolchains
 
 Both the `setup` script and `scripts/build.sh` look for compiler prefixes via
-the `CROSS_COMPILE_ARM`, `CROSS_COMPILE_ARM64`, and
-`CROSS_COMPILE_AMD64` environment variables. Typical prefixes for
-Linux-targeted toolchains are `arm-linux-gnueabihf-`, `aarch64-linux-gnu-`, and
-`x86_64-linux-gnu-`, while macOS now uses the `aarch64-elf-` prefix by
+the `CROSS_COMPILE_ARM` and `CROSS_COMPILE_ARM64` environment variables.
+Typical prefixes for Linux-targeted toolchains are `arm-linux-gnueabihf-` and
+`aarch64-linux-gnu-`, while macOS now uses the `aarch64-elf-` prefix by
 default. If these cross-compilers are not already available, they can be
 installed via your distribution, Homebrew, or built with
 [crosstool-ng](https://crosstool-ng.github.io/).
@@ -22,7 +21,7 @@ installed via your distribution, Homebrew, or built with
 2. Install the cross-compilers:
 
    ```bash
-   sudo apt install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu gcc-x86-64-linux-gnu
+   sudo apt install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
    ```
 
 3. Verify the installation:
@@ -30,7 +29,6 @@ installed via your distribution, Homebrew, or built with
    ```bash
    arm-linux-gnueabihf-gcc --version
    aarch64-linux-gnu-gcc --version
-   x86_64-linux-gnu-gcc --version
    ```
 
 After installing a toolchain, add its `bin` directory to your `PATH` and set
@@ -40,7 +38,6 @@ the expected prefixes:
 export PATH=/path/to/toolchain/bin:$PATH
 export CROSS_COMPILE_ARM=arm-linux-gnueabihf-
 export CROSS_COMPILE_ARM64=aarch64-linux-gnu-
-export CROSS_COMPILE_AMD64=x86_64-linux-gnu-
 ```
 
 Verify each compiler is on your `PATH` before invoking `scripts/build.sh` or
@@ -58,9 +55,6 @@ on macOS they are installed by the `coreutils` package with a `g` prefix.
 - `Required tool arm-linux-gnueabihf-gcc not found` indicates the ARM compiler
   is missing or not on your `PATH`. Install `gcc-arm-linux-gnueabihf` and
   ensure `CROSS_COMPILE_ARM=arm-linux-gnueabihf-` is exported.
-- `unrecognized command-line option '-m64'` appears when an x86_64 compiler is
-  unavailable. Install `gcc-x86-64-linux-gnu` and set
-  `CROSS_COMPILE_AMD64=x86_64-linux-gnu-`.
 
 ## macOS (Apple Silicon)
 


### PR DESCRIPTION
## Summary
- remove x86_64 and CROSS_COMPILE_AMD64 references from toolchain docs
- list only ARM cross-compilers in installation and verification steps

## Testing
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_e_68c7198665fc832f8a84c28a5bec816e