### PR TITLE
Ensure driver.c compiled in driver crate

### DIFF
--- a/src/driver/build.rs
+++ b/src/driver/build.rs
@@ -8,6 +8,9 @@ fn main() {
         .flag("-fno-builtin")
         .flag("-nostdlib");
 
+    // Ensure the top-level driver.c is compiled
+    build.file("driver.c");
+
     for entry in WalkDir::new("src") {
         let entry = entry.unwrap();
         if entry.file_type().is_file() {


### PR DESCRIPTION
## Summary
- include top-level `driver.c` in `cc` build script so it is compiled into the static library

## Testing
- `RUSTFLAGS="-C panic=abort" cargo +nightly check -p driver -Zbuild-std=core`
- `find target -name 'libdriver.a'`


------
https://chatgpt.com/codex/tasks/task_e_68c7c63b8b98832fac89503307a6f7b9