### PR TITLE
Remove variadic printk and enforce abort panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,8 @@
 [workspace]
 members = ["driver_picker", "src/linux_shims", "src/driver", "src/virtio_frontend", "src/l4rust/l4re-libc"]
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/src/linux_shims/Cargo.toml
+++ b/src/linux_shims/Cargo.toml
@@ -7,3 +7,9 @@ edition = "2021"
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/src/linux_shims/src/lib.rs
+++ b/src/linux_shims/src/lib.rs
@@ -1,18 +1,17 @@
 #![cfg_attr(not(test), no_std)]
-#![feature(c_variadic)]
 
-use core::ffi::{c_char, VaListImpl};
+use core::ffi::{c_char, c_void};
 use core::sync::atomic::{AtomicBool, Ordering};
 
 extern "C" {
-    fn vprintf(fmt: *const c_char, args: VaListImpl) -> i32;
+    fn vprintf(fmt: *const c_char, args: *mut c_void) -> i32;
 }
 
 static INIT_DONE: AtomicBool = AtomicBool::new(false);
 static mut EXIT_HANDLER: Option<extern "C" fn()> = None;
 
 #[no_mangle]
-pub unsafe extern "C" fn printk(fmt: *const c_char, args: ...) {
+pub unsafe extern "C" fn printk(fmt: *const c_char, args: *mut c_void) {
     vprintf(fmt, args);
 }
 


### PR DESCRIPTION
## Summary
- drop `c_variadic` use and change `printk` to take a `va_list` pointer
- build linux_shims with panic=abort

## Testing
- `cargo check -p linux_shims`


------
https://chatgpt.com/codex/tasks/task_e_68c7c64076c8832fa852ed6ac72b1da7