### PR TITLE
Fail fast when ARM Linux cross-compiler missing on macOS

### DIFF
--- a/scripts/common_build.sh
+++ b/scripts/common_build.sh
@@ -21,7 +21,9 @@ detect_cross_compilers() {
         if command -v arm-linux-gnueabihf-gcc >/dev/null 2>&1; then
           CROSS_COMPILE_ARM=arm-linux-gnueabihf-
         else
-          CROSS_COMPILE_ARM=arm-none-eabi-
+          echo "No Linux-targeted ARM cross compiler found (expected arm-linux-gnueabihf-gcc)." \
+            "Install it on macOS via Homebrew: 'brew install arm-linux-gnueabihf-gcc'." >&2
+          exit 1
         fi
       fi
 


### PR DESCRIPTION
## Summary
- avoid falling back to `arm-none-eabi-` on macOS
- instruct users to install `arm-linux-gnueabihf-gcc` via Homebrew and exit when absent

## Testing
- `bash -n scripts/common_build.sh`
- `bash -c 'source scripts/common_build.sh; detect_cross_compilers; echo CC_ARM=$CROSS_COMPILE_ARM CC_ARM64=$CROSS_COMPILE_ARM64'`
- `bash -c 'uname(){ echo Darwin; }; source scripts/common_build.sh; detect_cross_compilers; echo success'` *(fails as expected)*
