### PR TITLE
Simplify build_arm setup configuration

### DIFF
--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -75,15 +75,12 @@ if [ -f /workspace/.config ]; then
   echo "Using configuration from /workspace/.config"
   mkdir -p obj
   cp /workspace/.config obj/.config
-  ./setup setup
 elif [ -f scripts/l4re.config ]; then
   echo "Using configuration from scripts/l4re.config"
   mkdir -p obj
   cp scripts/l4re.config obj/.config
-  ./setup setup
 else
   ./setup config
-  ./setup setup
 fi
 ./setup --non-interactive
 


### PR DESCRIPTION
## Summary
- avoid redundant setup calls by running a single non-interactive setup once the configuration file is prepared

## Testing
- `cargo test` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*
- `shellcheck scripts/build_arm.sh`
