### PR TITLE
Automate Homebrew path setup on macOS

### DIFF
--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -67,11 +67,11 @@ brew install qemu e2fsprogs coreutils meson ninja pkg-config
 brew install arm-linux-gnueabihf-gcc aarch64-elf-gcc
 ```
 
-Ensure the Homebrew prefixes are in your `PATH` and define the compiler
-prefixes expected by the build scripts:
+The build scripts automatically run `brew --prefix` for `arm-linux-gnueabihf-gcc`,
+`aarch64-elf-gcc`, and `e2fsprogs` and prepend their `bin` directories to
+`PATH`. Define the compiler prefixes expected by the build scripts:
 
 ```bash
-export PATH="$(brew --prefix e2fsprogs)/bin:$(brew --prefix arm-linux-gnueabihf-gcc)/bin:$(brew --prefix aarch64-elf-gcc)/bin:$PATH"
 export CROSS_COMPILE_ARM=arm-linux-gnueabihf-
 # CROSS_COMPILE_ARM64 defaults to aarch64-elf-
 ```
@@ -93,5 +93,5 @@ scripts/build.sh --test  # CROSS_COMPILE_ARM64 defaults to aarch64-elf-
 ```
 
 Some tools, such as `mke2fs` from `e2fsprogs`, live outside Homebrew's default
-`bin` prefix; the `PATH` example above includes these locations.
+`bin` prefix, but the build scripts add these directories automatically.
 

--- a/scripts/common_build.sh
+++ b/scripts/common_build.sh
@@ -9,6 +9,21 @@ resolve_path() {
   fi
 }
 
+# Discover Homebrew tool prefixes on macOS and prepend their bin directories to
+# PATH.
+setup_macos_paths() {
+  if ! command -v brew >/dev/null 2>&1; then
+    return
+  fi
+
+  local formula prefix
+  for formula in arm-linux-gnueabihf-gcc aarch64-elf-gcc e2fsprogs; do
+    prefix=$(brew --prefix "$formula" 2>/dev/null) || continue
+    PATH="$prefix/bin:$PATH"
+  done
+  export PATH
+}
+
 # Detect suitable cross-compilers for ARM and ARM64.
 detect_cross_compilers() {
   if [ -z "${CROSS_COMPILE_ARM:-}" ] || [ -z "${CROSS_COMPILE_ARM64:-}" ]; then
@@ -16,6 +31,7 @@ detect_cross_compilers() {
     Darwin)
       local machine
       machine=$(uname -m)
+      setup_macos_paths
 
       if [ -z "${CROSS_COMPILE_ARM:-}" ]; then
         if command -v arm-linux-gnueabihf-gcc >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add `setup_macos_paths` to automatically prepend Homebrew toolchain bins to `PATH`
- hook automatic path setup into Darwin cross-compiler detection
- document Homebrew path discovery in macOS toolchain guide

## Testing
- `bash -n scripts/common_build.sh`
- `shellcheck scripts/common_build.sh`
