### PR TITLE
Automate GNU coreutils aliases on macOS

### DIFF
--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -47,9 +47,10 @@ When these variables are unset, the scripts attempt to choose sensible
 defaults based on `uname`; `CROSS_COMPILE_ARM64` falls back to the
 `aarch64-elf-` prefix.
 
-The build scripts rely on several GNU utilities such as `timeout`, `stat`, and
+The build scripts rely on GNU utilities such as `timeout`, `stat`, and
 `truncate`. Ensure GNU versions of these tools are available in your `PATH`;
-on macOS they are installed by the `coreutils` package with a `g` prefix.
+on macOS they are installed by the `coreutils` package with a `g` prefix. The
+build scripts automatically expose these tools under their expected names.
 
 ### Troubleshooting
 
@@ -76,14 +77,10 @@ export CROSS_COMPILE_ARM=arm-linux-gnueabihf-
 # CROSS_COMPILE_ARM64 defaults to aarch64-elf-
 ```
 
-macOS does not ship GNU `timeout` or several other GNU utilities required by
-the build. The `coreutils` formula installs them with a `g` prefix (e.g.,
-`gtimeout`). Either invoke these `g`-prefixed tools directly or alias them to
-the expected names:
-
-```bash
-alias timeout=gtimeout
-```
+macOS does not ship GNU `timeout` or several other utilities required by the
+build. The `coreutils` formula installs them with a `g` prefix (e.g.,
+`gtimeout`). The build scripts automatically create aliases so these tools are
+available as `timeout`, `stat`, and `truncate`.
 
 With the environment set up, a smoke test of the build can be run with:
 

--- a/scripts/common_build.sh
+++ b/scripts/common_build.sh
@@ -140,5 +140,26 @@ validate_tools() {
     echo "Unable to determine gmake version from '$make_version'" >&2
     exit 1
   fi
+
+  setup_macos_coreutils
+}
+
+# Create temporary aliases for GNU coreutils on macOS.
+setup_macos_coreutils() {
+  if [[ $(uname -s) != "Darwin" || -n "${GNU_COREUTILS_SETUP_DONE:-}" ]]; then
+    return
+  fi
+  GNU_COREUTILS_SETUP_DONE=1
+
+  local alias_dir
+  alias_dir=$(mktemp -d)
+  for util in stat truncate timeout; do
+    local gutil="g${util}"
+    if command -v "$gutil" >/dev/null 2>&1; then
+      ln -sf "$(command -v "$gutil")" "$alias_dir/$util"
+    fi
+  done
+  PATH="$alias_dir:$PATH"
+  export PATH
 }
 


### PR DESCRIPTION
## Summary
- create macOS helper to map gstat/gtruncate/gtimeout to stat/truncate/timeout via temporary symlinks
- export the aliases so downstream build steps use GNU coreutils
- document automated GNU coreutils setup and drop manual alias instructions

## Testing
- `bash -n scripts/common_build.sh`
- `cargo test` *(fails: unwinding panics are not supported without std)*


------
https://chatgpt.com/codex/tasks/task_e_68c7ff64cf74832f98d9bcb337755444