### PR TITLE
Add l4 dependency to driver_client example

### DIFF
--- a/src/examples/driver_client/Cargo.toml
+++ b/src/examples/driver_client/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 l4re = { path = "../../l4rust/l4re-rust" }
 l4re-libc = { path = "../../l4rust/l4re-libc" }
+l4 = { path = "../../l4rust/l4-rust" }
 
 [workspace]


### PR DESCRIPTION
## Summary
- add local `l4` crate dependency for the driver_client example

## Testing
- `cargo check` *(fails: l4/sys/ipc.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c80419de0c832fb0eae7880f4b5038