### PR TITLE
Add l4 dependency to driver_server

### DIFF
--- a/src/driver_server/Cargo.toml
+++ b/src/driver_server/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+l4 = { path = "../l4rust/l4-rust" }
 l4re = { path = "../l4rust/l4re-rust" }
 l4re-libc = { path = "../l4rust/l4re-libc" }
 driver = { path = "../driver" }


### PR DESCRIPTION
## Summary
- depend on the local l4 crate in driver_server

## Testing
- `cargo check` *(fails: l4/sys/ipc.h missing)*
