### PR TITLE
Add l4 dependency to net_server

### DIFF
--- a/src/net_server/Cargo.toml
+++ b/src/net_server/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+l4 = { path = "../l4rust/l4-rust" }
 l4re = { path = "../l4rust/l4re-rust" }
 l4re-libc = { path = "../l4rust/l4re-libc" }
 smoltcp = { version = "0.12.0", default-features = false, features = ["std", "proto-ipv4", "socket-udp", "socket-tcp", "medium-ethernet"] }


### PR DESCRIPTION
## Summary
- Add local `l4` crate as a dependency for `net_server`

## Testing
- `cargo check` *(fails: current package believes it's in a workspace when it's not)*
