### PR TITLE
Use g++ cross toolchains in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
         e2fsprogs \
         flex \
         gawk \
-        gcc-aarch64-linux-gnu \
-        gcc-arm-linux-gnueabihf \
+        g++-aarch64-linux-gnu \
+        g++-arm-linux-gnueabihf \
         git \
         graphviz \
         libgit-repository-perl \


### PR DESCRIPTION
## Summary
- replace the cross-compilation GCC packages with their corresponding G++ packages in the Docker image to ensure C++ tooling is available

## Testing
- not run
