### PR TITLE
Build driver with C++ compiler

### DIFF
--- a/src/driver/Makefile
+++ b/src/driver/Makefile
@@ -1,9 +1,14 @@
 CROSS_COMPILE ?= $(CROSS_COMPILE_ARM64)
 CROSS_COMPILE ?= aarch64-linux-gnu-
 
+CC := $(CROSS_COMPILE)g++
+CXX := $(CROSS_COMPILE)g++
+AR := $(CROSS_COMPILE)ar
+
 all:
-	CC=$(CROSS_COMPILE)g++ \
-	AR=$(CROSS_COMPILE)ar \
+	CC=$(CC) \
+	CXX=$(CXX) \
+	AR=$(AR) \
 	CROSS_COMPILE=$(CROSS_COMPILE) \
 	cargo build --manifest-path Cargo.toml --release --target aarch64-unknown-linux-gnu
 

--- a/src/driver/build.rs
+++ b/src/driver/build.rs
@@ -4,18 +4,19 @@ use walkdir::WalkDir;
 fn main() {
     let mut build = cc::Build::new();
     build
+        .cpp(true)
         .flag("-ffreestanding")
         .flag("-fno-builtin")
         .flag("-nostdlib");
 
-    // Ensure the top-level driver.c is compiled
-    build.file("driver.c");
+    // Ensure the top-level driver.cpp is compiled
+    build.file("driver.cpp");
 
     for entry in WalkDir::new("src") {
         let entry = entry.unwrap();
         if entry.file_type().is_file() {
             if let Some(ext) = entry.path().extension() {
-                if ext == "c" {
+                if ext == "c" || ext == "cpp" {
                     build.file(entry.path());
                 }
             }
@@ -24,7 +25,7 @@ fn main() {
 
     // Mirror CROSS_COMPILE setup from scripts/build_arm.sh
     if let Ok(prefix) = env::var("CROSS_COMPILE") {
-        build.compiler(format!("{}gcc", prefix));
+        build.compiler(format!("{}g++", prefix));
         build.archiver(format!("{}ar", prefix));
     }
     build.compile("driver");

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -1,8 +1,10 @@
 #include <stdio.h>
 
-extern void printk(const char *fmt, ...);
-extern void module_init(int (*init)(void));
-extern void module_exit(void (*exit)(void));
+extern "C" {
+    void printk(const char *fmt, ...);
+    void module_init(int (*init)(void));
+    void module_exit(void (*exit)(void));
+}
 
 static int my_init(void) {
     printk("driver init\n");
@@ -13,7 +15,7 @@ static void my_exit(void) {
     printk("driver exit\n");
 }
 
-void l4re_driver_start(void) {
+extern "C" void l4re_driver_start(void) {
     module_init(my_init);
     module_exit(my_exit);
 }


### PR DESCRIPTION
## Summary
- update the driver build script and Makefile to use the C++ cross compiler
- compile renamed driver.cpp along with any C/C++ sources

## Testing
- `cargo build -p driver`
