### PR TITLE
Use slab for fs_server file handles

### DIFF
--- a/src/fs_server/Cargo.toml
+++ b/src/fs_server/Cargo.toml
@@ -8,3 +8,4 @@ l4re = { path = "../l4rust/l4re-rust" }
 l4re-libc = { path = "../l4rust/l4re-libc" }
 fatfs = "0.3"
 libc = "0.2"
+slab = "0.4"


### PR DESCRIPTION
## Summary
- add the slab crate to fs_server
- switch file-handle tracking to Slab for insert/remove semantics
- update read/write/close paths to use descriptor-indexed access

## Testing
- cargo check -p fs_server *(fails: package ID specification `fs_server` did not match any packages)*
- cargo check --manifest-path src/fs_server/Cargo.toml *(fails: manifest expects to be in workspace but member is excluded)*


------
https://chatgpt.com/codex/tasks/task_e_68c87a197880832f8e3f4ff1cecc6cf4