### PR TITLE
Move setup script into scripts directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,16 @@ all:
 	fi
 
 clean:
-	@./setup clean
+	@scripts/setup.sh clean
 
 setup:
 	@if [ -d obj ]; then                                                            \
           echo "Snapshot has already been setup. Proceed with 'gmake setup' or 'gmake clean'.";    \
 	else                                                                            \
 	  export PATH=$$(pwd)/bin:$$PATH;                                               \
-	  chmod +x ./setup;     							\
-	  ./setup config || exit 1;                                           		\
-	  ./setup setup || exit 1;                                                      \
+	  chmod +x scripts/setup.sh;     							\
+	  scripts/setup.sh config || exit 1;                                           		\
+	  scripts/setup.sh setup || exit 1;                                                      \
 	  echo ====================================================================;    \
 	  echo ;                                                                        \
           echo Your L4Re tree is set up now. Type 'gmake' to build the tree. This;       \

--- a/docs/build.md
+++ b/docs/build.md
@@ -9,16 +9,16 @@ instructions.
 ## Repository setup
 
 Before running any of the build scripts, the L4Re snapshot must be configured.
-The setup script now provides a unified, non-interactive entry point which
+The `scripts/setup.sh` helper now provides a unified, non-interactive entry point which
 performs both the configuration and setup phases in a single call:
 
 ```bash
-./setup --non-interactive
+scripts/setup.sh --non-interactive
 ```
 
 This generates the necessary configuration files and Makefiles using sensible
-defaults. The traditional interactive invocation (`./setup config` followed by
-`./setup setup` or `gmake setup`) remains available for manual configuration.
+defaults. The traditional interactive invocation (`scripts/setup.sh config` followed by
+`scripts/setup.sh setup` or `gmake setup`) remains available for manual configuration.
 
 ## Containerized build
 
@@ -37,8 +37,8 @@ so nothing else needs to be installed on the host.
 
 For non-interactive Docker builds, the scripts look for an existing L4Re
 configuration in `/workspace/.config` or `scripts/l4re.config`. If either file
-is present, it is copied to `obj/.config` before running `setup`, allowing
-developers to tailor the build by editing `scripts/l4re.config`.
+is present, it is copied to `obj/.config` before running `scripts/setup.sh`,
+allowing developers to tailor the build by editing `scripts/l4re.config`.
 
 To boot the built image on your host, run:
 

--- a/scripts/build_arm.sh
+++ b/scripts/build_arm.sh
@@ -46,7 +46,7 @@ ARTIFACTS_DIR="out"
 
 # Start from a clean state
 if [ "$clean" = true ]; then
-  ./setup clean
+  scripts/setup.sh clean
 fi
 
 mkdir -p "$ARTIFACTS_DIR"
@@ -64,9 +64,9 @@ elif [ -f scripts/l4re.config ]; then
   mkdir -p obj
   cp scripts/l4re.config obj/.config
 else
-  ./setup config
+  scripts/setup.sh config
 fi
-./setup --non-interactive
+scripts/setup.sh --non-interactive
 
 # Build the Rust libc crate so other crates can link against it
 (

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/scripts/common_build.sh"
 
 # Handle optional non-interactive mode which runs both config and setup in
-# one go. When invoked as `./setup --non-interactive` the script will skip
+# one go. When invoked as `scripts/setup.sh --non-interactive` the script will skip
 # prompts and execute the combined steps automatically.
 cmd="$1"
 non_interactive=0


### PR DESCRIPTION
## Summary
- relocate the root-level setup helper into scripts/setup.sh and adjust its inline invocation comment
- update the Makefile and ARM build script to call scripts/setup.sh instead of ./setup
- refresh the build documentation to point to scripts/setup.sh for both interactive and non-interactive usage

## Testing
- Not run (not requested)

