### PR TITLE
Update example crate list and workspace metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,10 @@ obj/systemd/%/systemd:
 	@scripts/build.sh --no-clean
 
 EXAMPLE_CRATES := \
-src/ipc-example/client \
-src/ipc-example/server \
 src/fs_server \
-src/net_server
+src/net_server \
+src/driver_server \
+src/examples/driver_client
 
 examples:
 	@for crate in $(EXAMPLE_CRATES); do \

--- a/src/fs_server/Cargo.toml
+++ b/src/fs_server/Cargo.toml
@@ -9,3 +9,5 @@ l4re-libc = { path = "../l4rust/l4re-libc" }
 fatfs = "0.3"
 libc = "0.2"
 slab = "0.4"
+
+[workspace]

--- a/src/net_server/Cargo.toml
+++ b/src/net_server/Cargo.toml
@@ -8,3 +8,5 @@ l4 = { path = "../l4rust/l4-rust" }
 l4re = { path = "../l4rust/l4re-rust" }
 l4re-libc = { path = "../l4rust/l4re-libc" }
 smoltcp = { version = "0.12.0", default-features = false, features = ["std", "proto-ipv4", "socket-udp", "socket-tcp", "medium-ethernet"] }
+
+[workspace]


### PR DESCRIPTION
## Summary
- drop the obsolete ipc-example entries from the example build list and add the currently available crates
- mark the fs_server and net_server manifests with empty [workspace] tables so cargo treats them as standalone packages

## Testing
- `gmake examples` *(fails: missing L4 headers such as l4/sys/ipc.h in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c911530c30832fbf466b427bc4d73c