### PR TITLE
Clarify build.sh clean flags and update driver comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ scripts/build.sh          # builds natively
 CROSS_COMPILE=aarch64-elf- scripts/build.sh  # CROSS_COMPILE_ARM64 defaults to aarch64-elf-
 ```
 
-Build artifacts are placed under `out/`. 
+Pass `--clean` (the default) to force removal of previous build directories or
+`--no-clean` to reuse them for incremental builds. Build artifacts are placed
+under `out/`.
 
 **Fallback**, to cross-compile inside a container, run:
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -48,9 +48,9 @@ scripts/runqemu.sh
 
 ## Building for ARM
 
-Use `scripts/build.sh` to build the project. By default, previous build
-artifacts are removed before compilation. Passing `--no-clean` skips this
-cleanup.
+Use `scripts/build.sh` to build the project. The script removes previous build
+artifacts before compilation (the same effect as passing `--clean`). Provide
+`--no-clean` to skip this cleanup when iterating.
 
 Built components and images are collected under the `out/` directory. To boot
 an image on your host, run `scripts/runqemu.sh` and optionally pass the path to

--- a/src/driver/build.rs
+++ b/src/driver/build.rs
@@ -23,7 +23,7 @@ fn main() {
         }
     }
 
-    // Mirror CROSS_COMPILE setup from scripts/build.sh
+    // Mirror the unified scripts/build.sh handling of the CROSS_COMPILE prefix
     if let Ok(prefix) = env::var("CROSS_COMPILE") {
         build.compiler(format!("{}g++", prefix));
         build.archiver(format!("{}ar", prefix));


### PR DESCRIPTION
## Summary
- explain the `--clean` and `--no-clean` options for `scripts/build.sh` in the top-level README and build documentation
- update the driver build script comment to reference the unified `scripts/build.sh`

## Testing
- rg "build_arm\.sh"

