### PR TITLE
Fix directory check in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,7 +41,7 @@ if [ "$cmd" != "clean" ]; then
 fi
 
 # check we're in the right directory when needed
-if [ "$cmd" != "clean" ] && [ ! -d src/l4 -o ]; then
+if [ "$cmd" != "clean" ] && [ ! -d src/l4 ]; then
   echo "Call setup as ./$(basename $0) in the right directory"
   exit 1
 fi


### PR DESCRIPTION
## Summary
- replace the invalid directory existence test in `scripts/setup.sh` with a valid condition to avoid parse errors

## Testing
- bash -n scripts/setup.sh
- ./scripts/setup.sh

