### PR TITLE
Fix Bash cross-build to use gcc for C files

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -95,10 +95,10 @@ build_bash() {
   (
     cd "$bash_src_dir"
     gmake distclean >/dev/null 2>&1 || true
-    CC="${cross}g++" CXX="${cross}g++" AR="${cross}ar" RANLIB="${cross}ranlib" \
+    CC="${cross}gcc" CXX="${cross}g++" AR="${cross}ar" RANLIB="${cross}ranlib" \
       ./configure --host="$host" --without-bash-malloc
     gmake clean
-    CC="${cross}g++" CXX="${cross}g++" AR="${cross}ar" RANLIB="${cross}ranlib" \
+    CC="${cross}gcc" CXX="${cross}g++" AR="${cross}ar" RANLIB="${cross}ranlib" \
       gmake STATIC_LDFLAGS=-static
     cp bash "$REPO_ROOT/$out_dir/"
   )


### PR DESCRIPTION
## Summary
- use the cross gcc executable for `CC` inside `build_bash` so that C sources build with the proper compiler
- keep using the cross g++ executable for `CXX` and retain the existing build flow

## Testing
- `build_bash arm "$CROSS_COMPILE_ARM"`
- `build_bash arm64 "$CROSS_COMPILE_ARM64"`
