### PR TITLE
Apply Bash patch for Linux cross build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -117,6 +117,16 @@ if [ "$need_bash" = true ]; then
   BASH_URL="https://ftp.gnu.org/gnu/bash/bash-${BASH_VERSION}.tar.gz"
   bash_src_dir=$(mktemp -d src/bash-XXXXXX)
   curl -L "$BASH_URL" | tar -xz -C "$bash_src_dir" --strip-components=1
+  bash_patch_dir="$SCRIPT_DIR/patches/bash"
+  if [ -d "$bash_patch_dir" ]; then
+    (
+      cd "$bash_src_dir"
+      for patch_file in "$bash_patch_dir"/*.patch; do
+        [ -e "$patch_file" ] || continue
+        patch -p1 -N < "$patch_file"
+      done
+    )
+  fi
   build_bash arm "$CROSS_COMPILE_ARM"
   build_bash arm64 "$CROSS_COMPILE_ARM64"
   rm -rf "$bash_src_dir"

--- a/scripts/patches/bash/0001-add-unistd-include.patch
+++ b/scripts/patches/bash/0001-add-unistd-include.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/termcap/tparam.c b/lib/termcap/tparam.c
+index 7ef112b3..b6df1f8d 100644
+--- a/lib/termcap/tparam.c
++++ b/lib/termcap/tparam.c
+@@ -22,9 +22,9 @@ extern char *malloc ();
+ extern char *realloc ();
+ #endif
+ 
+-#ifdef HAVE_UNISTD_H
+-#include <unistd.h>
+-#endif
++#if defined (HAVE_UNISTD_H) || defined (__linux__)
++#  include <unistd.h>
++#endif
+ 
+ #if defined (HAVE_STRING_H)
+ #include <string.h>


### PR DESCRIPTION
## Summary
- add a Bash patch that ensures lib/termcap/tparam.c pulls in <unistd.h> when building for Linux so write is declared
- update scripts/build.sh to apply Bash patches after extracting the tarball

## Testing
- not run (network access to download Bash tarball is blocked in the container)


------
https://chatgpt.com/codex/tasks/task_e_68c9bbdb8f28832fb297455728a1364b