### PR TITLE
Fix systemd cross file to use gcc for C compiler

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -156,7 +156,8 @@ build_systemd() {
     rm -rf "$builddir"
     cat > cross.txt <<EOF
 [binaries]
-c = '${cross}g++'
+c = '${cross}gcc'
+cpp = '${cross}g++'
 ar = '${cross}ar'
 strip = '${cross}strip'
 


### PR DESCRIPTION
## Summary
- update the systemd cross-file generation to set `c = '${cross}gcc'` and add a `cpp` entry so Meson resolves the correct compilers

## Testing
- ./scripts/build.sh --no-clean *(fails later because the container lacks POSIX capability headers, but Meson’s C compiler sanity check now passes)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c3925644832f9a11b57556f653f3