### PR TITLE
Enable multiarch libcap packages in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:22.04
 
-RUN apt-get update && \
+RUN dpkg --add-architecture armhf \
+    && dpkg --add-architecture arm64 \
+    && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         bison \
         build-essential \
@@ -16,6 +18,8 @@ RUN apt-get update && \
         g++-arm-linux-gnueabihf \
         git \
         graphviz \
+        libcap-dev:arm64 \
+        libcap-dev:armhf \
         libgit-repository-perl \
         libncurses-dev \
         liburi-perl \


### PR DESCRIPTION
## Summary
- enable the armhf and arm64 architectures in the Ubuntu base image before running apt
- install the libcap-dev:armhf and libcap-dev:arm64 packages so their headers are available in the cross sysroots

## Testing
- `docker build -t l4rerust-builder -f docker/Dockerfile .` *(fails: docker command is not available in the execution environment)*
- `scripts/docker_build.sh` *(fails: ham bootstrap requires the Git::Repository perl module outside the container)*
