### PR TITLE
Document libcap headers requirement for systemd builds

### DIFF
--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -2,6 +2,13 @@
 
 The build scripts can produce a systemd-based image. `scripts/build.sh` fetches and cross-builds systemd for arm and arm64, then installs it together with unit files from `config/systemd` into the root filesystem. The same process can be invoked with `gmake systemd-image`.
 
+Cross-compiling systemd requires libcap headers for each target architecture. On
+Debian/Ubuntu hosts enable the `armhf` and `arm64` architectures and install
+`libcap-dev:armhf` and `libcap-dev:arm64` (see the detailed commands in
+[`docs/toolchains.md`](./toolchains.md)). The project Docker image will bundle
+these packages once the container fix lands; manual installation is only needed
+when building on your own host.
+
 Unit files placed in `config/systemd` are copied to `/lib/systemd/system` at build time. `bash.service` is enabled by default. To enable or disable other services, create or remove the corresponding symlinks under `/etc/systemd/system/<target>.wants/` or run `systemctl enable`/`disable` after boot.
 
 Systemd units interact with L4Re via capabilities exported in `config/cfg/bash.cfg`. Units that need a capability reference it through environment variables named `L4_CAP_<NAME>`. The file server demonstrates this pattern:

--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -31,6 +31,20 @@ installed via your distribution, Homebrew, or built with
    aarch64-linux-gnu-g++ --version
    ```
 
+4. Install target headers required for cross-building systemd:
+
+   ```bash
+   sudo dpkg --add-architecture armhf
+   sudo dpkg --add-architecture arm64
+   sudo apt update
+   sudo apt install libcap-dev:armhf libcap-dev:arm64
+   ```
+
+   The systemd build expects libcap headers for each target architecture. The
+   provided Docker image will include these packages once the container fix
+   lands; manual installation is only necessary when building directly on your
+   host machine.
+
 After installing a toolchain, add its `bin` directory to your `PATH` and set
 the expected prefixes:
 


### PR DESCRIPTION
## Summary
- note the requirement for target libcap development headers when cross-compiling systemd
- add Debian/Ubuntu commands for enabling armhf/arm64 architectures and installing libcap-dev for each target
- clarify that the project Docker image will include these packages once the container fix lands

## Testing
- not run (docs only)

