### PR TITLE
Add libxcrypt and cmake to Docker builder image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ RUN dpkg --add-architecture armhf \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         bison \
         build-essential \
+        cmake \
         cpanminus \
         curl \
         device-tree-compiler \
@@ -20,6 +21,8 @@ RUN dpkg --add-architecture armhf \
         graphviz \
         libcap-dev:arm64 \
         libcap-dev:armhf \
+        libxcrypt-dev:arm64 \
+        libxcrypt-dev:armhf \
         libgit-repository-perl \
         libncurses-dev \
         liburi-perl \


### PR DESCRIPTION
## Summary
- add `cmake` and the `libxcrypt-dev` cross packages to the builder Dockerfile so libcrypt is available in the sysroots

## Testing
- `docker build -t l4rerust-builder -f docker/Dockerfile .` *(fails: `docker` command not available in execution environment)*
- `scripts/docker_build.sh systemd-image` *(fails: `Git::Repository` Perl module missing when running outside the Docker environment)*
