### PR TITLE
Document Linux toolchain requirements for systemd builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ scripts/build.sh          # builds natively
 
 **Mac:**
 ```bash
-CROSS_COMPILE=aarch64-elf- scripts/build.sh  # CROSS_COMPILE_ARM64 defaults to aarch64-elf-
+CROSS_COMPILE=aarch64-linux-gnu- scripts/build.sh  # Override any aarch64-elf- default.
 ```
 
 Pass `--clean` (the default) to force removal of previous build directories or

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -2,12 +2,21 @@
 
 The build scripts can produce a systemd-based image. `scripts/build.sh` fetches and cross-builds systemd for arm and arm64, then installs it together with unit files from `config/systemd` into the root filesystem. The same process can be invoked with `gmake systemd-image`.
 
-Cross-compiling systemd requires libcap headers for each target architecture. On
-Debian/Ubuntu hosts enable the `armhf` and `arm64` architectures and install
-`libcap-dev:armhf` and `libcap-dev:arm64` (see the detailed commands in
+Cross-compiling systemd requires Linux-targeted cross-compilers that provide
+glibc libraries. Ensure `CROSS_COMPILE_ARM=arm-linux-gnueabihf-` and
+`CROSS_COMPILE_ARM64=aarch64-linux-gnu-` are exported before launching the
+build. The stripped-down `aarch64-elf-` toolchain is insufficient because it
+omits `libcrypt` and other glibc libraries required by systemd.
+
+Systemd also depends on libcap headers and `libcrypt` for each target
+architecture. On Debian/Ubuntu hosts enable the `armhf` and `arm64`
+architectures and install `libcap-dev:armhf`, `libcap-dev:arm64`,
+`libxcrypt-dev:armhf`, and `libxcrypt-dev:arm64` (see the detailed commands in
 [`docs/toolchains.md`](./toolchains.md)). The project Docker image will bundle
 these packages once the container fix lands; manual installation is only needed
-when building on your own host.
+when building on your own host. If the systemd build fails due to missing
+`libcrypt` libraries, install the packages and rerun
+`scripts/build.sh --no-clean` to reuse the existing build directory.
 
 Unit files placed in `config/systemd` are copied to `/lib/systemd/system` at build time. `bash.service` is enabled by default. To enable or disable other services, create or remove the corresponding symlinks under `/etc/systemd/system/<target>.wants/` or run `systemctl enable`/`disable` after boot.
 

--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -4,10 +4,11 @@
 
 Both the `setup` script and `scripts/build.sh` look for compiler prefixes via
 the `CROSS_COMPILE_ARM` and `CROSS_COMPILE_ARM64` environment variables.
-Typical prefixes for Linux-targeted toolchains are `arm-linux-gnueabihf-` and
-`aarch64-linux-gnu-`, while macOS now uses the `aarch64-elf-` prefix by
-default. If these cross-compilers are not already available, they can be
-installed via your distribution, Homebrew, or built with
+System components that rely on glibc, such as systemd, must be built with
+Linux-targeted toolchains that provide those libraries. Use the
+`arm-linux-gnueabihf-` and `aarch64-linux-gnu-` prefixes when setting up these
+cross-compilers. If they are not already available, they can be installed via
+your distribution, Homebrew, or built with
 [crosstool-ng](https://crosstool-ng.github.io/).
 
 ### Installing compilers on Debian/Ubuntu
@@ -31,19 +32,23 @@ installed via your distribution, Homebrew, or built with
    aarch64-linux-gnu-g++ --version
    ```
 
-4. Install target headers required for cross-building systemd:
+4. Install target headers and libraries required for cross-building systemd:
 
    ```bash
    sudo dpkg --add-architecture armhf
    sudo dpkg --add-architecture arm64
    sudo apt update
-   sudo apt install libcap-dev:armhf libcap-dev:arm64
+   sudo apt install libcap-dev:armhf libcap-dev:arm64 \
+                    libxcrypt-dev:armhf libxcrypt-dev:arm64
    ```
 
    The systemd build expects libcap headers for each target architecture. The
    provided Docker image will include these packages once the container fix
    lands; manual installation is only necessary when building directly on your
-   host machine.
+   host machine. The matching `libxcrypt-dev` packages provide `libcrypt`
+   within the cross sysroots. Without them the systemd build fails while
+   linking. After installing the missing packages re-run
+   `scripts/build.sh --no-clean` to retry without discarding prior work.
 
 After installing a toolchain, add its `bin` directory to your `PATH` and set
 the expected prefixes:
@@ -51,15 +56,16 @@ the expected prefixes:
 ```bash
 export PATH=/path/to/toolchain/bin:$PATH
 export CROSS_COMPILE_ARM=arm-linux-gnueabihf-
-export CROSS_COMPILE_ARM64=aarch64-elf-
+export CROSS_COMPILE_ARM64=aarch64-linux-gnu-
 ```
 
 Verify each compiler is on your `PATH` before invoking `scripts/build.sh` or
 `setup`.
 
 When these variables are unset, the scripts attempt to choose sensible
-defaults based on `uname`; `CROSS_COMPILE_ARM64` falls back to the
-`aarch64-elf-` prefix.
+defaults based on `uname`. Override any non-Linux prefix (such as
+`aarch64-elf-`) with `aarch64-linux-gnu-` before building systemd or any other
+component that links against glibc-provided libraries.
 
 The build scripts rely on GNU utilities such as `timeout`, `stat`, and
 `truncate`. Ensure GNU versions of these tools are available in your `PATH`;
@@ -79,16 +85,16 @@ compilers:
 
 ```bash
 brew install qemu e2fsprogs coreutils meson ninja pkg-config
-brew install arm-linux-gnueabihf-g++ aarch64-elf-g++
+brew install arm-linux-gnueabihf-g++ aarch64-linux-gnu-g++
 ```
 
 The build scripts automatically run `brew --prefix` for `arm-linux-gnueabihf-g++`,
-`aarch64-elf-g++`, and `e2fsprogs` and prepend their `bin` directories to
+`aarch64-linux-gnu-g++`, and `e2fsprogs` and prepend their `bin` directories to
 `PATH`. Define the compiler prefixes expected by the build scripts:
 
 ```bash
 export CROSS_COMPILE_ARM=arm-linux-gnueabihf-
-# CROSS_COMPILE_ARM64 defaults to aarch64-elf-
+export CROSS_COMPILE_ARM64=aarch64-linux-gnu-
 ```
 
 macOS does not ship GNU `timeout` or several other utilities required by the
@@ -100,7 +106,8 @@ With the environment set up, a smoke test of the build can be run with:
 
 ```bash
 CROSS_COMPILE_ARM=arm-linux-gnueabihf- \
-scripts/build.sh --test  # CROSS_COMPILE_ARM64 defaults to aarch64-elf-
+CROSS_COMPILE_ARM64=aarch64-linux-gnu- \
+scripts/build.sh --test
 ```
 
 Some tools, such as `mke2fs` from `e2fsprogs`, live outside Homebrew's default


### PR DESCRIPTION
## Summary
- require Linux-targeted cross-compiler prefixes when building components like systemd
- document installing libxcrypt-dev for armhf and arm64 targets alongside libcap headers
- note that missing libxcrypt causes systemd builds to fail and to rerun scripts/build.sh --no-clean after installing the packages

## Testing
- not run (documentation-only change)
