### PR TITLE
Make systemd libcrypt optional

### DIFF
--- a/scripts/patches/systemd/disable-libcrypt.patch
+++ b/scripts/patches/systemd/disable-libcrypt.patch
@@ -1,0 +1,68 @@
+--- a/meson.build	2024-02-27 17:26:04.000000000 +0000
++++ b/meson.build	2025-09-17 04:46:52.476708239 +0000
+@@ -1013,9 +1013,11 @@
+ libm = cc.find_library('m')
+ libdl = cc.find_library('dl')
+ libcrypt = dependency('libcrypt', 'libxcrypt', required : false)
+-if not libcrypt.found()
++libcrypt_found = libcrypt.found()
++if not libcrypt_found
+         # fallback to use find_library() if libcrypt is provided by glibc, e.g. for LibreELEC.
+-        libcrypt = cc.find_library('crypt')
++        libcrypt = cc.find_library('crypt', required : false)
++        libcrypt_found = libcrypt.found()
+ endif
+ libcap = dependency('libcap')
+ 
+--- a/src/shared/meson.build	2024-02-27 17:26:04.000000000 +0000
++++ b/src/shared/meson.build	2025-09-17 04:46:54.824717720 +0000
+@@ -316,7 +316,6 @@
+                   libacl,
+                   libblkid,
+                   libcap,
+-                  libcrypt,
+                   libdl,
+                   libgcrypt,
+                   libiptc_cflags,
+@@ -333,6 +332,10 @@
+                   libxz,
+                   libzstd]
+ 
++if libcrypt_found
++        libshared_deps += libcrypt
++endif
++
+ libshared_sym_path = meson.current_source_dir() / 'libshared.sym'
+ libshared_build_dir = meson.current_build_dir()
+ 
+--- a/src/test/meson.build	2024-02-27 17:26:04.000000000 +0000
++++ b/src/test/meson.build	2025-09-17 04:47:20.520826070 +0000
+@@ -194,6 +194,16 @@
+         threads,
+ ]
+ 
++if libcrypt_found
++        executables += [
++                test_template + {
++                        'sources' : files('test-libcrypt-util.c'),
++                        'dependencies' : libcrypt,
++                        'timeout' : 120,
++                },
++        ]
++endif
++
+ executables += [
+         test_template + {
+                 'sources' : files('test-acl-util.c'),
+@@ -303,11 +313,6 @@
+                 'dependencies' : libm,
+         },
+         test_template + {
+-                'sources' : files('test-libcrypt-util.c'),
+-                'dependencies' : libcrypt,
+-                'timeout' : 120,
+-        },
+-        test_template + {
+                 'sources' : files('test-libmount.c'),
+                 'dependencies' : [
+                         libmount,


### PR DESCRIPTION
## Summary
- add a systemd patch that makes libcrypt optional and skips the related test when the library is absent
- teach scripts/build.sh to apply systemd patches, drop the libcrypt probe, and disable libcrypt consumers via Meson options

## Testing
- gmake systemd-image *(fails: missing Git::Repository Perl module in container)*
