### PR TITLE
Add cmake prerequisite to build validation

### DIFF
--- a/scripts/common_build.sh
+++ b/scripts/common_build.sh
@@ -109,6 +109,7 @@ validate_tools() {
     mke2fs
     debugfs
     ssh-keygen
+    cmake
     meson
     ninja
     pkg-config


### PR DESCRIPTION
## Summary
- add cmake to the list of build prerequisites validated by scripts/common_build.sh

## Testing
- PATH="/tmp/testbin:$PATH" bash -lc 'source scripts/common_build.sh; CROSS_COMPILE_ARM= CROSS_COMPILE_ARM64=; validate_tools' # fails without cmake as expected
- PATH="/tmp/testbin:$PATH" bash -lc 'source scripts/common_build.sh; CROSS_COMPILE_ARM= CROSS_COMPILE_ARM64=; validate_tools; echo "validate_tools succeeded"'
