### PR TITLE
Support building libcap with L4Re ELF toolchains

### DIFF
--- a/pkg/include/linux/capability.h
+++ b/pkg/include/linux/capability.h
@@ -1,0 +1,427 @@
+/*
+ * This is <linux/capability.h>
+ *
+ * Andrew G. Morgan <morgan@kernel.org>
+ * Alexander Kjeldaas <astor@guardian.no>
+ * with help from Aleph1, Roland Buresund and Andrew Main.
+ *
+ * See here for the libcap library ("POSIX draft" compliance):
+ *
+ * https://git.kernel.org/pub/scm/libs/libcap/libcap.git/refs/
+ * http://www.kernel.org/pub/linux/libs/security/linux-privs/
+ */
+
+#ifndef _UAPI_LINUX_CAPABILITY_H
+#define _UAPI_LINUX_CAPABILITY_H
+
+#include <stdint.h>
+#define __u32 uint32_t
+#define __le32 __u32
+
+/* User-level do most of the mapping between kernel and user
+   capabilities based on the version tag given by the kernel. The
+   kernel might be somewhat backwards compatible, but don't bet on
+   it. */
+
+/* Note, cap_t, is defined by POSIX (draft) to be an "opaque" pointer to
+   a set of three capability sets.  The transposition of 3*the
+   following structure to such a composite is better handled in a user
+   library since the draft standard requires the use of malloc/free
+   etc.. */
+
+#define _LINUX_CAPABILITY_VERSION_1  0x19980330
+#define _LINUX_CAPABILITY_U32S_1     1
+
+#define _LINUX_CAPABILITY_VERSION_2  0x20071026  /* deprecated - use v3 */
+#define _LINUX_CAPABILITY_U32S_2     2
+
+#define _LINUX_CAPABILITY_VERSION_3  0x20080522
+#define _LINUX_CAPABILITY_U32S_3     2
+
+typedef struct __user_cap_header_struct {
+	__u32 version;
+	int pid;
+} *cap_user_header_t;
+
+typedef struct __user_cap_data_struct {
+        __u32 effective;
+        __u32 permitted;
+        __u32 inheritable;
+} *cap_user_data_t;
+
+
+#define VFS_CAP_REVISION_MASK	0xFF000000
+#define VFS_CAP_REVISION_SHIFT	24
+#define VFS_CAP_FLAGS_MASK	~VFS_CAP_REVISION_MASK
+#define VFS_CAP_FLAGS_EFFECTIVE	0x000001
+
+#define VFS_CAP_REVISION_1	0x01000000
+#define VFS_CAP_U32_1           1
+#define XATTR_CAPS_SZ_1         (sizeof(__le32)*(1 + 2*VFS_CAP_U32_1))
+
+#define VFS_CAP_REVISION_2	0x02000000
+#define VFS_CAP_U32_2           2
+#define XATTR_CAPS_SZ_2         (sizeof(__le32)*(1 + 2*VFS_CAP_U32_2))
+
+#define VFS_CAP_REVISION_3	0x03000000
+#define VFS_CAP_U32_3           VFS_CAP_U32_2
+#define XATTR_CAPS_SZ_3         (sizeof(__le32)+XATTR_CAPS_SZ_2)
+
+/*
+ * Kernel capabilities default to v2. The v3 VFS caps are only used,
+ * at present, for namespace specific filesystem capabilities.
+ */
+#define XATTR_CAPS_SZ           XATTR_CAPS_SZ_2
+#define VFS_CAP_U32             VFS_CAP_U32_2
+#define VFS_CAP_REVISION	VFS_CAP_REVISION_2
+
+#define _VFS_CAP_DATA_HEAD \
+	__le32 magic_etc;            /* Little endian */ \
+	struct {                                         \
+		__le32 permitted;    /* Little endian */ \
+		__le32 inheritable;  /* Little endian */ \
+	} data[VFS_CAP_U32]
+
+struct vfs_cap_data {
+	_VFS_CAP_DATA_HEAD;
+};
+
+struct vfs_ns_cap_data {
+	_VFS_CAP_DATA_HEAD;
+	__le32 rootid;
+};
+
+#ifndef __KERNEL__
+
+/*
+ * Backwardly compatible definition for source code - trapped in a
+ * 32-bit world. If you find you need this, please consider using
+ * libcap to untrap yourself...
+ */
+#define _LINUX_CAPABILITY_VERSION  _LINUX_CAPABILITY_VERSION_1
+#define _LINUX_CAPABILITY_U32S     _LINUX_CAPABILITY_U32S_1
+
+#endif
+
+
+/**
+ ** POSIX-draft defined capabilities.
+ **/
+
+/* In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
+   overrides the restriction of changing file ownership and group
+   ownership. */
+
+#define CAP_CHOWN            0
+
+/* Override all DAC access, including ACL execute access if
+   [_POSIX_ACL] is defined. Excluding DAC access covered by
+   CAP_LINUX_IMMUTABLE. */
+
+#define CAP_DAC_OVERRIDE     1
+
+/* Overrides all DAC restrictions regarding read and search on files
+   and directories, including ACL restrictions if [_POSIX_ACL] is
+   defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE. */
+
+#define CAP_DAC_READ_SEARCH  2
+
+/* Overrides all restrictions about allowed operations on files, where
+   file owner ID must be equal to the user ID, except where CAP_FSETID
+   is applicable. It doesn't override MAC and DAC restrictions. */
+
+#define CAP_FOWNER           3
+
+/* Overrides the following restrictions that the effective user ID
+   shall match the file owner ID when setting the S_ISUID and S_ISGID
+   bits on that file; that the effective group ID (or one of the
+   supplementary group IDs) shall match the file owner ID when setting
+   the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
+   cleared on successful return from chown(2) (not implemented). */
+
+#define CAP_FSETID           4
+
+/* Overrides the restriction that the real or effective user ID of a
+   process sending a signal must match the real or effective user ID
+   of the process receiving the signal. */
+
+#define CAP_KILL             5
+
+/* Allows setgid(2) manipulation */
+/* Allows setgroups(2) */
+/* Allows forged gids on socket credentials passing. */
+
+#define CAP_SETGID           6
+
+/* Allows set*uid(2) manipulation (including fsuid). */
+/* Allows forged pids on socket credentials passing. */
+
+#define CAP_SETUID           7
+
+
+/**
+ ** Linux-specific capabilities
+ **/
+
+/* Without VFS support for capabilities:
+ *   Transfer any capability in your permitted set to any pid,
+ *   remove any capability in your permitted set from any pid
+ * With VFS support for capabilities (neither of above, but)
+ *   Add any capability from current's capability bounding set
+ *       to the current process' inheritable set
+ *   Allow taking bits out of capability bounding set
+ *   Allow modification of the securebits for a process
+ */
+
+#define CAP_SETPCAP          8
+
+/* Allow modification of S_IMMUTABLE and S_APPEND file attributes */
+
+#define CAP_LINUX_IMMUTABLE  9
+
+/* Allows binding to TCP/UDP sockets below 1024 */
+/* Allows binding to ATM VCIs below 32 */
+
+#define CAP_NET_BIND_SERVICE 10
+
+/* Allow broadcasting, listen to multicast */
+
+#define CAP_NET_BROADCAST    11
+
+/* Allow interface configuration */
+/* Allow administration of IP firewall, masquerading and accounting */
+/* Allow setting debug option on sockets */
+/* Allow modification of routing tables */
+/* Allow setting arbitrary process / process group ownership on
+   sockets */
+/* Allow binding to any address for transparent proxying (also via NET_RAW) */
+/* Allow setting TOS (type of service) */
+/* Allow setting promiscuous mode */
+/* Allow clearing driver statistics */
+/* Allow multicasting */
+/* Allow read/write of device-specific registers */
+/* Allow activation of ATM control sockets */
+
+#define CAP_NET_ADMIN        12
+
+/* Allow use of RAW sockets */
+/* Allow use of PACKET sockets */
+/* Allow binding to any address for transparent proxying (also via NET_ADMIN) */
+
+#define CAP_NET_RAW          13
+
+/* Allow locking of shared memory segments */
+/* Allow mlock and mlockall (which doesn't really have anything to do
+   with IPC) */
+
+#define CAP_IPC_LOCK         14
+
+/* Override IPC ownership checks */
+
+#define CAP_IPC_OWNER        15
+
+/* Insert and remove kernel modules - modify kernel without limit */
+#define CAP_SYS_MODULE       16
+
+/* Allow ioperm/iopl access */
+/* Allow sending USB messages to any device via /dev/bus/usb */
+
+#define CAP_SYS_RAWIO        17
+
+/* Allow use of chroot() */
+
+#define CAP_SYS_CHROOT       18
+
+/* Allow ptrace() of any process */
+
+#define CAP_SYS_PTRACE       19
+
+/* Allow configuration of process accounting */
+
+#define CAP_SYS_PACCT        20
+
+/* Allow configuration of the secure attention key */
+/* Allow administration of the random device */
+/* Allow examination and configuration of disk quotas */
+/* Allow setting the domainname */
+/* Allow setting the hostname */
+/* Allow calling bdflush() */
+/* Allow mount() and umount(), setting up new smb connection */
+/* Allow some autofs root ioctls */
+/* Allow nfsservctl */
+/* Allow VM86_REQUEST_IRQ */
+/* Allow to read/write pci config on alpha */
+/* Allow irix_prctl on mips (setstacksize) */
+/* Allow flushing all cache on m68k (sys_cacheflush) */
+/* Allow removing semaphores */
+/* Used instead of CAP_CHOWN to "chown" IPC message queues, semaphores
+   and shared memory */
+/* Allow locking/unlocking of shared memory segment */
+/* Allow turning swap on/off */
+/* Allow forged pids on socket credentials passing */
+/* Allow setting readahead and flushing buffers on block devices */
+/* Allow setting geometry in floppy driver */
+/* Allow turning DMA on/off in xd driver */
+/* Allow administration of md devices (mostly the above, but some
+   extra ioctls) */
+/* Allow tuning the ide driver */
+/* Allow access to the nvram device */
+/* Allow administration of apm_bios, serial and bttv (TV) device */
+/* Allow manufacturer commands in isdn CAPI support driver */
+/* Allow reading non-standardized portions of pci configuration space */
+/* Allow DDI debug ioctl on sbpcd driver */
+/* Allow setting up serial ports */
+/* Allow sending raw qic-117 commands */
+/* Allow enabling/disabling tagged queuing on SCSI controllers and sending
+   arbitrary SCSI commands */
+/* Allow setting encryption key on loopback filesystem */
+/* Allow setting zone reclaim policy */
+
+#define CAP_SYS_ADMIN        21
+
+/* Allow use of reboot() */
+
+#define CAP_SYS_BOOT         22
+
+/* Allow raising priority and setting priority on other (different
+   UID) processes */
+/* Allow use of FIFO and round-robin (realtime) scheduling on own
+   processes and setting the scheduling algorithm used by another
+   process. */
+/* Allow setting cpu affinity on other processes */
+
+#define CAP_SYS_NICE         23
+
+/* Override resource limits. Set resource limits. */
+/* Override quota limits. */
+/* Override reserved space on ext2 filesystem */
+/* Modify data journaling mode on ext3 filesystem (uses journaling
+   resources) */
+/* NOTE: ext2 honors fsuid when checking for resource overrides, so
+   you can override using fsuid too */
+/* Override size restrictions on IPC message queues */
+/* Allow more than 64hz interrupts from the real-time clock */
+/* Override max number of consoles on console allocation */
+/* Override max number of keymaps */
+
+#define CAP_SYS_RESOURCE     24
+
+/* Allow manipulation of system clock */
+/* Allow irix_stime on mips */
+/* Allow setting the real-time clock */
+
+#define CAP_SYS_TIME         25
+
+/* Allow configuration of tty devices */
+/* Allow vhangup() of tty */
+
+#define CAP_SYS_TTY_CONFIG   26
+
+/* Allow the privileged aspects of mknod() */
+
+#define CAP_MKNOD            27
+
+/* Allow taking of leases on files */
+
+#define CAP_LEASE            28
+
+/* Allow writing the audit log via unicast netlink socket */
+
+#define CAP_AUDIT_WRITE      29
+
+/* Allow configuration of audit via unicast netlink socket */
+
+#define CAP_AUDIT_CONTROL    30
+
+/* Set capabilities on files. */
+
+#define CAP_SETFCAP	     31
+
+/* Override MAC access.
+   The base kernel enforces no MAC policy.
+   An LSM may enforce a MAC policy, and if it does and it chooses
+   to implement capability based overrides of that policy, this is
+   the capability it should use to do so. */
+
+#define CAP_MAC_OVERRIDE     32
+
+/* Allow MAC configuration or state changes.
+   The base kernel requires no MAC configuration.
+   An LSM may enforce a MAC policy, and if it does and it chooses
+   to implement capability based checks on modifications to that
+   policy or the data required to maintain it, this is the
+   capability it should use to do so. */
+
+#define CAP_MAC_ADMIN        33
+
+/* Allow configuring the kernel's syslog (printk behaviour) */
+
+#define CAP_SYSLOG           34
+
+/* Allow triggering something that will wake the system */
+
+#define CAP_WAKE_ALARM            35
+
+/* Allow preventing system suspends */
+
+#define CAP_BLOCK_SUSPEND    36
+
+/* Allow reading the audit log via multicast netlink socket */
+
+#define CAP_AUDIT_READ       37
+
+/* Allow system performance and observability privileged operations using
+ * perf_events, i915_perf and other kernel subsystems. */
+
+#define CAP_PERFMON	     38
+
+/*
+ * CAP_BPF allows the following BPF operations:
+ * - Creating all types of BPF maps
+ * - Advanced verifier features
+ *   - Indirect variable access
+ *   - Bounded loops
+ *   - BPF to BPF function calls
+ *   - Scalar precision tracking
+ *   - Larger complexity limits
+ *   - Dead code elimination
+ *   - And potentially other features
+ * - Loading BPF Type Format (BTF) data
+ * - Retrieve xlated and JITed code of BPF programs
+ * - Use bpf_spin_lock() helper
+ *
+ * CAP_PERFMON relaxes the verifier checks further:
+ * - BPF progs can use of pointer-to-integer conversions
+ * - speculation attack hardening measures are bypassed
+ * - bpf_probe_read to read arbitrary kernel memory is allowed
+ * - bpf_trace_printk to print kernel memory is allowed
+ *
+ * CAP_SYS_ADMIN is required to use bpf_probe_write_user.
+ *
+ * CAP_SYS_ADMIN is required to iterate system wide loaded
+ * programs, maps, links, BTFs and convert their IDs to file descriptors.
+ *
+ * CAP_PERFMON and CAP_BPF are required to load tracing programs.
+ * CAP_NET_ADMIN and CAP_BPF are required to load networking programs.
+ */
+
+#define CAP_BPF		     39
+
+/* Allow checkpoint/restore related operations */
+/* Allow PID selection during clone3() */
+/* Allow writing to ns_last_pid */
+
+#define CAP_CHECKPOINT_RESTORE 40
+
+#define CAP_LAST_CAP         CAP_CHECKPOINT_RESTORE
+
+#define cap_valid(x) ((x) >= 0 && (x) <= CAP_LAST_CAP)
+
+/*
+ * Bit location of each capability (used by user-space library and kernel)
+ */
+
+#define CAP_TO_INDEX(x)     ((x) >> 5)        /* 1 << 5 == bits in __u32 */
+#define CAP_TO_MASK(x)      (1u << ((x) & 31)) /* mask for indexed __u32 */
+
+#endif /* _UAPI_LINUX_CAPABILITY_H */

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -136,8 +136,13 @@ BASH_URL="https://ftp.gnu.org/gnu/bash/bash-${BASH_VERSION}.tar.gz"
 build_libcap() {
   local arch="$1" cross="$2" expected_version="$3"
   local triple="$(${cross}g++ -dumpmachine)"
-  if [[ "$triple" != *-linux-* ]]; then
-    echo "${cross}g++ targets '$triple', but libcap requires a Linux-targeted toolchain" >&2
+  local microkernel=false
+  if [[ "$triple" == *-linux-* ]]; then
+    microkernel=false
+  elif [[ "$triple" == *-elf-* || "$triple" == *-elf ]]; then
+    microkernel=true
+  else
+    echo "${cross}g++ targets '$triple', but libcap requires a Linux or L4Re ELF toolchain" >&2
     exit 1
   fi
   local out_dir="$ARTIFACTS_DIR/libcap/$arch"
@@ -148,16 +153,45 @@ build_libcap() {
   local install_prefix="$REPO_ROOT/$out_dir"
   rm -rf "$install_prefix"
   mkdir -p "$install_prefix"
+  local -a make_args=(
+    "BUILD_CC=gcc"
+    "CC=${cross}gcc"
+    "AR=${cross}ar"
+    "RANLIB=${cross}ranlib"
+    "prefix=$install_prefix"
+    "lib=lib"
+  )
+  if [ "$microkernel" = true ]; then
+    make_args+=(
+      "KERNEL_HEADERS=$REPO_ROOT/pkg/include"
+      "PTHREADS=no"
+      "SHARED=no"
+    )
+  fi
   (
     cd "$libcap_src_dir"
-    gmake -C libcap distclean >/dev/null 2>&1 || true
-    gmake -C libcap clean >/dev/null 2>&1 || true
-    BUILD_CC=gcc CC="${cross}gcc" AR="${cross}ar" RANLIB="${cross}ranlib" \
-      prefix="$install_prefix" lib=lib gmake -C libcap install
+    gmake -C libcap "${make_args[@]}" distclean >/dev/null 2>&1 || true
+    gmake -C libcap "${make_args[@]}" clean >/dev/null 2>&1 || true
+    gmake -C libcap "${make_args[@]}" install
   )
-  if [ ! -f "$install_prefix/lib/pkgconfig/libcap.pc" ]; then
+  if [ "$microkernel" = true ]; then
+    local shim_header="$REPO_ROOT/pkg/include/linux/capability.h"
+    if [ ! -f "$shim_header" ]; then
+      echo "Missing capability shim header at $shim_header" >&2
+      exit 1
+    fi
+    mkdir -p "$install_prefix/include/linux"
+    cp "$shim_header" "$install_prefix/include/linux/"
+  fi
+  local pkgconfig_file="$install_prefix/lib/pkgconfig/libcap.pc"
+  if [ -f "$pkgconfig_file" ]; then
+    local tmp_pc
+    tmp_pc=$(mktemp)
+    sed "s/^Version:.*/Version: $expected_version/" "$pkgconfig_file" >"$tmp_pc"
+    mv "$tmp_pc" "$pkgconfig_file"
+  else
     mkdir -p "$install_prefix/lib/pkgconfig"
-    cat >"$install_prefix/lib/pkgconfig/libcap.pc" <<EOF
+    cat >"$pkgconfig_file" <<EOF
 prefix=$install_prefix
 exec_prefix=\${prefix}
 libdir=\${prefix}/lib


### PR DESCRIPTION
## Summary
- allow libcap builds with either Linux or L4Re ELF cross triples by tailoring the make arguments and rewriting the staged pkg-config metadata
- supply a linux/capability.h shim so L4Re toolchains without glibc headers can compile libcap and stage matching includes

## Testing
- `CROSS_COMPILE_ARM=arm-elf- CROSS_COMPILE_ARM64=aarch64-elf- scripts/build.sh --no-clean` *(fails later while building L4Re images because the stub environment lacks full build targets, but libcap stages successfully beforehand)*

