### PR TITLE
Document staged libcrypt artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ In case of issues with the Docker build container, run:
 ```bash
 docker image rm l4rerust-builder
 ```
+
+### Staged capability and crypt libraries
+
+`scripts/build.sh` cross-compiles libcap and libcrypt (via libxcrypt) for each
+supported architecture. The staged headers, libraries, and pkg-config files are
+written to `out/libcap/<arch>` and `out/libcrypt/<arch>` and can be installed
+into other prefixes with `gmake -C pkg/libcap install ...` or
+`gmake -C pkg/libcrypt install ...`.
+
 ## Further documents
 
 ### Building for ARM

--- a/docs/toolchains.md
+++ b/docs/toolchains.md
@@ -32,7 +32,7 @@ your distribution, Homebrew, or built with
    aarch64-linux-gnu-g++ --version
    ```
 
-4. Install target headers and libraries that are not built in-tree:
+4. (Optional) Install target headers and libraries that are not built in-tree:
 
    ```bash
    sudo dpkg --add-architecture armhf
@@ -41,12 +41,14 @@ your distribution, Homebrew, or built with
    sudo apt install libxcrypt-dev:armhf libxcrypt-dev:arm64
    ```
 
-   `scripts/build.sh` downloads and stages libcap locally, so only the
-   `libxcrypt-dev` packages are required to provide `libcrypt` within each
-   cross sysroot. The matching `libxcrypt-dev` packages provide `libcrypt`
-   within the cross sysroots. Without them the systemd build fails while
-   linking. After installing the missing packages re-run
-   `scripts/build.sh --no-clean` to retry without discarding prior work.
+   `scripts/build.sh` downloads and stages libcap and libcrypt (via libxcrypt)
+   locally under `out/libcap/<arch>` and `out/libcrypt/<arch>`, so the cross
+   sysroots no longer need to supply `libcrypt` by default. Install the
+   distribution packages only if you prefer to consume `libcrypt` from the
+   system-provided sysroots, then rerun `scripts/build.sh --no-clean` to retry
+   without discarding prior work. The staged artifacts can also be installed
+   into other prefixes with `gmake -C pkg/libcap install ...` and
+   `gmake -C pkg/libcrypt install ...`.
 
 After installing a toolchain, add its `bin` directory to your `PATH` and set
 the expected prefixes:


### PR DESCRIPTION
## Summary
- describe that the systemd documentation now notes the staged libcap/libcrypt artifacts and how to publish them
- update the Debian/Ubuntu toolchain guidance to make libxcrypt optional and refer to pkg/libcrypt
- mention the staged libcap/libcrypt packages in the README overview

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cabc416dd8832fb518764f76ac8fb3