### PR TITLE
Update Dockerfile for staged libcrypt build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,9 +18,8 @@ RUN dpkg --add-architecture armhf \
         g++-aarch64-linux-gnu \
         g++-arm-linux-gnueabihf \
         git \
+        gperf \
         graphviz \
-        libxcrypt-dev:arm64 \
-        libxcrypt-dev:armhf \
         libgit-repository-perl \
         libncurses-dev \
         liburi-perl \


### PR DESCRIPTION
## Summary
- remove the libxcrypt cross packages from the builder image now that libcrypt is staged from source
- add gperf so the libxcrypt build can regenerate its generated sources if required

## Testing
- `docker build -t l4rerust-builder -f docker/Dockerfile .` *(fails: `docker` command not available in the execution environment)*