### PR TITLE
Add CMake configuration entry point and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(l4rerust LANGUAGES C CXX)
+
+# Expose cache variables mirroring the CROSS_COMPILE_* environment variables.
+set(_l4rerust_cross_defaults
+    CROSS_COMPILE_ARM "arm-linux-gnueabihf-"
+    CROSS_COMPILE_ARM64 "aarch64-linux-gnu-"
+    CROSS_COMPILE_MIPS32R2 "mips-linux-"
+    CROSS_COMPILE_MIPS32R6 "mips-linux-"
+    CROSS_COMPILE_MIPS64R2 "mips-linux-"
+    CROSS_COMPILE_MIPS64R6 "mips-linux-"
+)
+
+while(_l4rerust_cross_defaults)
+  list(POP_FRONT _l4rerust_cross_defaults _var)
+  list(POP_FRONT _l4rerust_cross_defaults _default)
+
+  if(DEFINED ENV{${_var}} AND NOT "$ENV{${_var}}" STREQUAL "")
+    set(_value "$ENV{${_var}}")
+  else()
+    set(_value "${_default}")
+  endif()
+
+  set(${_var}
+      "${_value}"
+      CACHE STRING "Cross-compiler prefix (mirrors ${_var})."
+  )
+endwhile()
+
+unset(_value)
+unset(_var)
+unset(_l4rerust_cross_defaults)
+
+# Location of the upstream l4re-core checkout.
+if(DEFINED ENV{L4RE_CORE_DIR} AND NOT "$ENV{L4RE_CORE_DIR}" STREQUAL "")
+  set(_l4rerust_l4re_core_default "$ENV{L4RE_CORE_DIR}")
+else()
+  set(_l4rerust_l4re_core_default "${CMAKE_CURRENT_SOURCE_DIR}/src/l4re-core")
+endif()
+set(L4RE_CORE_DIR
+    "${_l4rerust_l4re_core_default}"
+    CACHE PATH "Path to the L4Re core checkout used for headers and libraries."
+)
+unset(_l4rerust_l4re_core_default)
+
+add_subdirectory(src/l4rust/libl4re-wrapper)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,42 @@ In case of issues with the Docker build container, run:
 docker image rm l4rerust-builder
 ```
 
+## CMake build
+
+The repository also exposes a CMake entry point at the repository root. Create
+an out-of-source build directory and configure it with:
+
+```bash
+cmake -S . -B build
+```
+
+The configuration step accepts the usual `CMAKE_TOOLCHAIN_FILE` argument if you
+maintain a bespoke toolchain description:
+
+```bash
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE=/path/to/toolchain.cmake
+```
+
+Alternatively, pass compilers directly on the command line. The cache variables
+`CROSS_COMPILE_ARM`, `CROSS_COMPILE_ARM64`, `CROSS_COMPILE_MIPS32R2`,
+`CROSS_COMPILE_MIPS32R6`, `CROSS_COMPILE_MIPS64R2`, and `CROSS_COMPILE_MIPS64R6`
+mirror the existing environment variables used by the gmake flow, allowing
+toolchain prefixes to be configured without exporting environment state:
+
+```bash
+cmake -S . -B build \
+  -DL4RE_CORE_DIR=/path/to/l4re-core \
+  -DCROSS_COMPILE_ARM=arm-linux-gnueabihf- \
+  -DCROSS_COMPILE_ARM64=aarch64-linux-gnu-
+```
+
+After configuration, build the selected targets as usual:
+
+```bash
+cmake --build build
+```
+
 ### Staged capability and crypt libraries
 
 `scripts/build.sh` cross-compiles libcap and libcrypt (via libxcrypt) for each

--- a/src/l4rust/libl4re-wrapper/CMakeLists.txt
+++ b/src/l4rust/libl4re-wrapper/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(libl4re-wrapper INTERFACE)
+
+target_include_directories(libl4re-wrapper INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)


### PR DESCRIPTION
## Summary
- add a repository-root CMakeLists.txt that exposes cross-toolchain cache variables and the l4re-core location
- introduce a minimal CMake target under src/l4rust/libl4re-wrapper so the directory can be added by the top-level project
- document how to drive the new CMake flow alongside the existing gmake instructions

## Testing
- cmake -S . -B build-test
