### PR TITLE
Ensure systemd build finds staged libcap libraries

### DIFF
--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -13,10 +13,14 @@ architecture. By default `scripts/build.sh` downloads both libcap and
 libxcrypt, cross-compiles them with the configured toolchains, and stages the
 headers, libraries, and pkg-config files under `out/libcap/<arch>` and
 `out/libcrypt/<arch>`. Meson picks up these self-contained artifacts when
-building systemd, so external `libxcrypt-dev` packages are no longer required
-in the cross sysroots. You may still install the distribution-provided packages
-if you prefer to rely on them, then rerun `scripts/build.sh --no-clean` to
-retry the systemd build without discarding prior work.
+ building systemd, so external `libxcrypt-dev` packages are no longer required
+ in the cross sysroots. The systemd build also injects `out/libcap/<arch>/lib`
+ (and `out/libcrypt/<arch>/lib`) into `LIBRARY_PATH`/`LD_LIBRARY_PATH` inside
+ the build subshell before Meson/Ninja run, ensuring `${cross}gcc` searches the
+ staged directories even when pkg-config resolves to bare `-lcap` or `-lcrypt`
+ arguments. You may still install the distribution-provided packages if you
+ prefer to rely on them, then rerun `scripts/build.sh --no-clean` to retry the
+ systemd build without discarding prior work.
 
 If you already maintain custom libcap or libxcrypt builds, set the
 `SYSTEMD_LIBCAP_PREFIX` and/or `SYSTEMD_LIBCRYPT_PREFIX` environment variables

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -608,6 +608,39 @@ build_systemd() {
     else
       unset PKG_CONFIG_SYSROOT_DIR
     fi
+
+    local -a staged_lib_dirs=()
+    local lib_dir
+    for lib_dir in "$libcap_prefix/lib" "$libcrypt_prefix/lib"; do
+      if [ -d "$lib_dir" ]; then
+        staged_lib_dirs+=("$lib_dir")
+      fi
+    done
+
+    if [ ${#staged_lib_dirs[@]} -gt 0 ]; then
+      local staged_lib_path=""
+      for lib_dir in "${staged_lib_dirs[@]}"; do
+        if [ -n "$staged_lib_path" ]; then
+          staged_lib_path="$staged_lib_path:$lib_dir"
+        else
+          staged_lib_path="$lib_dir"
+        fi
+      done
+
+      local old_library_path="${LIBRARY_PATH:-}"
+      if [ -n "$old_library_path" ]; then
+        export LIBRARY_PATH="$staged_lib_path:$old_library_path"
+      else
+        export LIBRARY_PATH="$staged_lib_path"
+      fi
+
+      local old_ld_library_path="${LD_LIBRARY_PATH:-}"
+      if [ -n "$old_ld_library_path" ]; then
+        export LD_LIBRARY_PATH="$staged_lib_path:$old_ld_library_path"
+      else
+        export LD_LIBRARY_PATH="$staged_lib_path"
+      fi
+    fi
     builddir="build-$arch"
     rm -rf "$builddir"
     mkdir -p "$builddir"


### PR DESCRIPTION
## Summary
- prepend the staged libcap/libcrypt library directories to LIBRARY_PATH and LD_LIBRARY_PATH during the systemd build
- document the new library path handling in docs/systemd.md

## Testing
- scripts/build.sh --no-clean *(fails: curl 403 while downloading libcap tarball from git.kernel.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cae70f91d0832f8a5d6c75c08a6184