### PR TITLE
Disable additional systemd features

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -672,8 +672,60 @@ cpu_family = '${cpu}'
 cpu = '${cpu}'
 endian = 'little'
 EOF
-    meson setup "$builddir" --cross-file cross.txt --prefix=/usr \
-      -Dhomed=false -Dfirstboot=false -Dtests=false
+    local -a meson_setup_args=(
+      "$builddir"
+      --cross-file cross.txt
+      --prefix=/usr
+      -Dhomed=disabled
+      -Dfirstboot=false
+      -Dtests=false
+      -Dmachined=false
+      -Dnetworkd=false
+      -Dnss-myhostname=false
+      -Dnss-mymachines=disabled
+      -Dnss-resolve=disabled
+      -Dnss-systemd=false
+      -Dportabled=false
+      -Dresolve=false
+      -Dtimesyncd=false
+      -Dbacklight=false
+      -Dbinfmt=false
+      -Dcoredump=false
+      -Dhibernate=false
+      -Dhostnamed=false
+      -Dhwdb=false
+      -Dlocaled=false
+      -Dlogind=false
+      -Dpstore=false
+      -Dquotacheck=false
+      -Drandomseed=false
+      -Drfkill=false
+      -Dsysext=false
+      -Dtimedated=false
+      -Dtmpfiles=false
+      -Duserdb=false
+      -Dvconsole=false
+      -Dudev=false
+      -Dremovable=false
+      -Daudit=disabled
+      -Dbzip2=disabled
+      -Delfutils=disabled
+      -Dgnutls=disabled
+      -Didn=false
+      -Dlibiptc=disabled
+      -Dlz4=disabled
+      -Dopenssl=disabled
+      -Dpcre2=disabled
+      -Dpolkit=disabled
+      -Dpwquality=disabled
+      -Dseccomp=disabled
+      -Dselinux=disabled
+      -Dtpm=false
+      -Dtpm2=disabled
+      -Dxz=disabled
+      -Dzlib=disabled
+    )
+    meson setup "${meson_setup_args[@]}"
     ninja -C "$builddir" systemd || ninja -C "$builddir"
     DESTDIR="$REPO_ROOT/$out_dir/root" meson install -C "$builddir"
     cp "$REPO_ROOT/$out_dir/root/lib/systemd/systemd" "$REPO_ROOT/$out_dir/"

--- a/scripts/patches/systemd/disable-components.patch
+++ b/scripts/patches/systemd/disable-components.patch
@@ -1,0 +1,156 @@
+--- a/meson_options.txt	2024-02-27 17:26:04.000000000 +0000
++++ b/meson_options.txt	2025-09-17 19:22:15.176444716 +0000
+@@ -120,6 +120,8 @@
+        description : 'install the systemd-localed stack')
+ option('machined', type : 'boolean',
+        description : 'install the systemd-machined stack')
++option('udev', type : 'boolean', value : true,
++       description : 'install the systemd-udevd stack')
+ option('portabled', type : 'boolean',
+        description : 'install the systemd-portabled stack')
+ option('sysext', type : 'boolean',
+@@ -152,6 +154,8 @@
+        description : 'support for firstboot mechanism')
+ option('randomseed', type : 'boolean',
+        description : 'support for restoring random seed')
++option('removable', type : 'boolean', value : true,
++       description : 'install the systemd-remount-fs helper')
+ option('backlight', type : 'boolean',
+        description : 'support for restoring backlight state')
+ option('vconsole', type : 'boolean',
+--- a/meson.build	2024-02-27 17:26:04.000000000 +0000
++++ b/meson.build	2025-09-17 19:23:03.306870968 +0000
+@@ -1603,6 +1603,7 @@
+                 'pstore',
+                 'quotacheck',
+                 'randomseed',
++                'removable',
+                 'resolve',
+                 'rfkill',
+                 'smack',
+@@ -1612,6 +1613,7 @@
+                 'timesyncd',
+                 'tmpfiles',
+                 'tpm',
++                'udev',
+                 'userdb',
+                 'utmp',
+                 'vconsole',
+@@ -2126,7 +2128,13 @@
+ # systemd-networkd requires 'libsystemd_network'
+ subdir('src/libsystemd-network')
+ # hwdb requires 'udev_link_with' and 'udev_rpath'
+-subdir('src/udev')
++if get_option('udev')
++	subdir('src/udev')
++else
++	udev_link_with = []
++	udev_rpath = ''
++	udev_pc = []
++endif
+ 
+ subdir('src/ac-power')
+ subdir('src/analyze')
+@@ -2233,7 +2241,11 @@
+ subdir('src/ukify/test')  # needs to be last for test_env variable
+ subdir('test/fuzz')
+ 
+-alias_target('devel', libsystemd_pc, libudev_pc, systemd_pc, udev_pc)
++devel_targets = [libsystemd_pc, libudev_pc, systemd_pc]
++if get_option('udev')
++	devel_targets += [udev_pc]
++endif
++alias_target('devel', devel_targets)
+ 
+ ############################################################
+ 
+@@ -2457,7 +2469,9 @@
+ 
+ ############################################################
+ 
+-subdir('rules.d')
++if get_option('udev')
++	subdir('rules.d')
++endif
+ subdir('test')
+ 
+ ############################################################
+@@ -2801,6 +2815,7 @@
+         ['pstore'],
+         ['quotacheck'],
+         ['randomseed'],
++        ['removable'],
+         ['repart'],
+         ['resolve'],
+         ['rfkill'],
+@@ -2812,6 +2827,7 @@
+         ['timedated'],
+         ['timesyncd'],
+         ['tmpfiles'],
++        ['udev'],
+         ['userdb'],
+         ['vconsole'],
+         ['vmspawn'],
+--- a/src/remount-fs/meson.build	2024-02-27 17:26:04.000000000 +0000
++++ b/src/remount-fs/meson.build	2025-09-17 19:23:22.859853013 +0000
+@@ -3,6 +3,7 @@
+ executables += [
+         libexec_template + {
+                 'name' : 'systemd-remount-fs',
++                'conditions' : ['ENABLE_REMOVABLE'],
+                 'sources' : files('remount-fs.c'),
+         },
+ ]
+--- a/units/meson.build	2024-02-27 17:26:04.000000000 +0000
++++ b/units/meson.build	2025-09-17 19:23:40.388734993 +0000
+@@ -95,7 +95,7 @@
+         },
+         {
+           'file' : 'initrd-udevadm-cleanup-db.service',
+-          'conditions' : ['ENABLE_INITRD'],
++          'conditions' : ['ENABLE_INITRD', 'ENABLE_UDEV'],
+         },
+         {
+           'file' : 'initrd-usr-fs.target',
+@@ -525,7 +525,10 @@
+           'symlinks' : ['sysinit.target.wants/'],
+         },
+         { 'file' : 'systemd-reboot.service' },
+-        { 'file' : 'systemd-remount-fs.service.in' },
++        {
++          'file' : 'systemd-remount-fs.service.in',
++          'conditions' : ['ENABLE_REMOVABLE'],
++        },
+         {
+           'file' : 'systemd-repart.service.in',
+           'conditions' : ['ENABLE_REPART'],
+@@ -632,21 +635,28 @@
+           'conditions' : ['ENABLE_TMPFILES'],
+           'symlinks' : ['sysinit.target.wants/'],
+         },
+-        { 'file' : 'systemd-udev-settle.service' },
++        {
++          'file' : 'systemd-udev-settle.service',
++          'conditions' : ['ENABLE_UDEV'],
++        },
+         {
+           'file' : 'systemd-udev-trigger.service',
++          'conditions' : ['ENABLE_UDEV'],
+           'symlinks' : ['sysinit.target.wants/'],
+         },
+         {
+           'file' : 'systemd-udevd-control.socket',
++          'conditions' : ['ENABLE_UDEV'],
+           'symlinks' : ['sockets.target.wants/'],
+         },
+         {
+           'file' : 'systemd-udevd-kernel.socket',
++          'conditions' : ['ENABLE_UDEV'],
+           'symlinks' : ['sockets.target.wants/'],
+         },
+         {
+           'file' : 'systemd-udevd.service.in',
++          'conditions' : ['ENABLE_UDEV'],
+           'symlinks' : ['sysinit.target.wants/'],
+         },
+         {


### PR DESCRIPTION
## Summary
- introduce a patch that adds Meson toggles for udev and the remount helper and conditions the related build targets
- pass explicit `-D<option>` settings in `scripts/build.sh` to disable the requested daemons, NSS modules, and optional libraries when building systemd
- document the intentionally disabled systemd feature set for downstream consumers

## Testing
- scripts/build.sh --no-clean *(fails: missing Git::Repository perl module in ham)*
- meson setup build-test … *(fails: dependency gperf is unavailable in the container)*
