### PR TITLE
Update systemd libcap removal patch

### DIFF
--- a/scripts/patches/systemd/remove-libcap.patch
+++ b/scripts/patches/systemd/remove-libcap.patch
@@ -1,14 +1,15 @@
---- a/meson.build
-+++ b/meson.build
-@@ -1017,7 +1017,6 @@
-         # fallback to use find_library() if libcrypt is provided by glibc, e.g. for LibreELEC.
-         libcrypt = cc.find_library('crypt')
+--- a/meson.build	2025-09-18 06:47:54.704140468 +0000
++++ b/meson.build	2025-09-18 06:48:01.724158991 +0000
+@@ -1019,8 +1019,6 @@
+         libcrypt = cc.find_library('crypt', required : false)
+         libcrypt_found = libcrypt.found()
  endif
 -libcap = dependency('libcap')
- 
+-
  # On some architectures, libatomic is required. But on some installations,
  # it is found, but actual linking fails. So let's try to use it opportunistically.
-@@ -1953,7 +1952,6 @@
+ # If it is installed, but not needed, it will be dropped because of --as-needed.
+@@ -1958,7 +1956,6 @@
          install_dir : libdir,
          pic : static_libsystemd_pic,
          dependencies : [libblkid,
@@ -16,3 +17,53 @@
                          libdl,
                          libgcrypt,
                          liblz4,
+--- a/src/basic/meson.build	2025-09-18 06:47:54.692140441 +0000
++++ b/src/basic/meson.build	2025-09-18 06:48:02.672161249 +0000
+@@ -273,8 +273,7 @@
+         basic_sources,
+         fundamental_sources,
+         include_directories : basic_includes,
+-        dependencies : [libcap,
+-                        libm,
++        dependencies : [libm,
+                         librt,
+                         threads,
+                         userspace],
+--- a/src/shared/meson.build	2025-09-18 06:47:54.704140468 +0000
++++ b/src/shared/meson.build	2025-09-18 06:48:03.588163432 +0000
+@@ -315,7 +315,6 @@
+ libshared_deps = [threads,
+                   libacl,
+                   libblkid,
+-                  libcap,
+                   libdl,
+                   libgcrypt,
+                   libiptc_cflags,
+--- a/src/systemctl/meson.build	2024-02-27 17:26:04.000000000 +0000
++++ b/src/systemctl/meson.build	2025-09-18 06:48:04.516165642 +0000
+@@ -55,7 +55,6 @@
+                 'sources' : systemctl_sources,
+                 'link_with' : systemctl_link_with,
+                 'dependencies' : [
+-                        libcap,
+                         liblz4,
+                         libselinux,
+                         libxz,
+--- a/src/test/meson.build	2025-09-18 06:47:54.704140468 +0000
++++ b/src/test/meson.build	2025-09-18 06:48:05.440167843 +0000
+@@ -238,15 +238,6 @@
+                 'type' : 'manual',
+         },
+         test_template + {
+-                'sources' : files('test-cap-list.c') +
+-                            generated_gperf_headers,
+-                'dependencies' : libcap,
+-        },
+-        test_template + {
+-                'sources' : files('test-capability.c'),
+-                'dependencies' : libcap,
+-        },
+-        test_template + {
+                 'sources' : files('test-chase-manual.c'),
+                 'type' : 'manual',
+         },


### PR DESCRIPTION
## Summary
- drop the libcap dependency assignment from systemd's top-level Meson build and remove it from libbasic, libshared and systemctl link lists
- stop building the libcap-based systemd tests so Meson no longer references the missing dependency

## Testing
- meson setup build -Dauto_features=disabled -Dtests=false *(fails later because libmount dependency is disabled)*
- rg "libcap" -g"meson.build"
