### PR TITLE
Refresh systemd test patches

### DIFF
--- a/scripts/patches/systemd/disable-libcrypt.patch
+++ b/scripts/patches/systemd/disable-libcrypt.patch
@@ -35,12 +35,9 @@
  libshared_sym_path = meson.current_source_dir() / 'libshared.sym'
  libshared_build_dir = meson.current_build_dir()
  
---- a/src/test/meson.build	2024-02-27 17:26:04.000000000 +0000
-+++ b/src/test/meson.build	2025-09-17 04:47:20.520826070 +0000
-@@ -194,6 +194,16 @@
-         threads,
- ]
- 
+--- a/src/test/meson.build      2024-02-27 17:26:04.000000000 +0000
++++ b/src/test/meson.build      2025-09-17 04:47:20.520826070 +0000
+@@ -196,0 +197,10 @@
 +if libcrypt_found
 +        executables += [
 +                test_template + {
@@ -51,18 +48,9 @@
 +        ]
 +endif
 +
- executables += [
-         test_template + {
-                 'sources' : files('test-acl-util.c'),
-@@ -303,11 +313,6 @@
-                 'dependencies' : libm,
-         },
-         test_template + {
+@@ -305,5 +314,0 @@
+-        test_template + {
 -                'sources' : files('test-libcrypt-util.c'),
 -                'dependencies' : libcrypt,
 -                'timeout' : 120,
 -        },
--        test_template + {
-                 'sources' : files('test-libmount.c'),
-                 'dependencies' : [
-                         libmount,

--- a/scripts/patches/systemd/remove-libmount.patch
+++ b/scripts/patches/systemd/remove-libmount.patch
@@ -382,3 +382,40 @@ new file mode 100644
 +        UNUSED(userns_fd);
 +        return -EOPNOTSUPP;
 +}
+diff --git a/src/test/meson.build b/src/test/meson.build
+--- a/src/test/meson.build
++++ b/src/test/meson.build
+@@ -163,8 +163,7 @@ simple_tests += files(
+ ############################################################
+ 
+ common_test_dependencies = [
+         libblkid,
+-        libmount,
+         librt,
+         libseccomp,
+         libselinux,
+@@ -258,13 +257,6 @@ executables += [
+                 'dependencies' : libcrypt,
+                 'timeout' : 120,
+         },
+-        test_template + {
+-                'sources' : files('test-libmount.c'),
+-                'dependencies' : [
+-                        libmount,
+-                        threads,
+-                ],
+-        },
+         test_template + {
+                 'sources' : files('test-loopback.c'),
+                 'dependencies' : common_test_dependencies,
+@@ -276,10 +268,6 @@ executables += [
+                 'sources' : files('test-mempress.c'),
+                 'dependencies' : threads,
+         },
+-        test_template + {
+-                'sources' : files('test-mount-util.c'),
+-                'dependencies' : libmount,
+-        },
+         test_template + {
+                 'sources' : files('test-netlink-manual.c'),
+                 'dependencies' : libkmod,


### PR DESCRIPTION
## Summary
- remove libmount from the systemd test patch so the common dependencies and libmount-specific test templates no longer reference libmount
- refresh the disable-libcrypt patch with the zero-context src/test/meson.build hunk that matches the updated layout

## Testing
- meson setup build -Dtests=true -Dinstall-tests=false --prefix=/tmp/systemd-prefix
