### PR TITLE
Guard fuzz link fuzz directive on udev option

### DIFF
--- a/scripts/patches/systemd/disable-components.patch
+++ b/scripts/patches/systemd/disable-components.patch
@@ -177,3 +177,21 @@ index 6e0a9b1..c7c7d2a 100644
 +                error('Unknown filesystems defined in kernel headers:\n\n' + r.stdout())
 +        endif
 +endif
+diff --git a/test/fuzz/meson.build b/test/fuzz/meson.build
+index 99d6302..ad1af12 100644
+--- a/test/fuzz/meson.build
++++ b/test/fuzz/meson.build
+@@ -7,4 +7,8 @@
+- directives = [['fuzz-network-parser', 'directives.network', networkd_network_gperf_gperf],
+-               ['fuzz-netdev-parser', 'directives.netdev',   networkd_netdev_gperf_gperf],
+-               ['fuzz-link-parser', 'directives.link',       udev_link_gperf_gperf],
+-              ]
++ directives = [['fuzz-network-parser', 'directives.network', networkd_network_gperf_gperf],
++               ['fuzz-netdev-parser', 'directives.netdev',   networkd_netdev_gperf_gperf],
++              ]
++
++if get_option('udev')
++        directives += [['fuzz-link-parser', 'directives.link', udev_link_gperf_gperf]]
++endif
++
+ foreach tuple : directives


### PR DESCRIPTION
## Summary
- extend the disable-components patch to only add the fuzz-link parser directives when udev stays enabled, avoiding references to udev_link_gperf_gperf in reduced builds

## Testing
- ~/.pyenv/versions/3.12.10/bin/meson setup build-native --prefix=/usr -Dhomed=disabled -Dfirstboot=false -Dtests=false -Dmachined=false -Dnetworkd=false -Dcheck-filesystems=false -Dnss-myhostname=false -Dnss-mymachines=disabled -Dnss-resolve=disabled -Dnss-systemd=false -Dportabled=false -Dresolve=false -Dtimesyncd=false -Dbacklight=false -Dbinfmt=false -Dcoredump=false -Dhibernate=false -Dhostnamed=false -Dhwdb=false -Dlocaled=false -Dlogind=false -Djournald=false -Dpstore=false -Dquotacheck=false -Drandomseed=false -Drfkill=false -Dsysext=false -Dtimedated=false -Dtmpfiles=false -Duserdb=false -Dvconsole=false -Dudev=false -Dremovable=false -Daudit=disabled -Dbzip2=disabled -Delfutils=disabled -Dgnutls=disabled -Didn=false -Dlibiptc=disabled -Dlz4=disabled -Dopenssl=disabled -Dpcre2=disabled -Dpolkit=disabled -Dpwquality=disabled -Dseccomp=disabled -Dselinux=disabled -Dtpm=false -Dtpm2=disabled -Dxz=disabled -Dzlib=disabled

------
https://chatgpt.com/codex/tasks/task_e_68cbe7670470832fb507e05ad79c6c79