### PR TITLE
Refresh systemd disable-components patch context

### DIFF
--- a/scripts/patches/systemd/disable-components.patch
+++ b/scripts/patches/systemd/disable-components.patch
@@ -182,13 +182,13 @@ index 99d6302..ad1af12 100644
 --- a/test/fuzz/meson.build
 +++ b/test/fuzz/meson.build
 @@ -7,4 +7,8 @@
-- directives = [['fuzz-network-parser', 'directives.network', networkd_network_gperf_gperf],
--               ['fuzz-netdev-parser', 'directives.netdev',   networkd_netdev_gperf_gperf],
--               ['fuzz-link-parser', 'directives.link',       udev_link_gperf_gperf],
--              ]
-+ directives = [['fuzz-network-parser', 'directives.network', networkd_network_gperf_gperf],
-+               ['fuzz-netdev-parser', 'directives.netdev',   networkd_netdev_gperf_gperf],
-+              ]
+-directives = [['fuzz-network-parser', 'directives.network', networkd_network_gperf_gperf],
+-              ['fuzz-netdev-parser', 'directives.netdev',   networkd_netdev_gperf_gperf],
+-              ['fuzz-link-parser', 'directives.link',       udev_link_gperf_gperf],
+-             ]
++directives = [['fuzz-network-parser', 'directives.network', networkd_network_gperf_gperf],
++              ['fuzz-netdev-parser', 'directives.netdev',   networkd_netdev_gperf_gperf],
++             ]
 +
 +if get_option('udev')
 +        directives += [['fuzz-link-parser', 'directives.link', udev_link_gperf_gperf]]


### PR DESCRIPTION
## Summary
- refresh the disable-components patch hunk for test/fuzz/meson.build to match systemd v255.4
- retain only the network fuzzers in the literal list and gate fuzz-link-parser behind the udev option

## Testing
- manual systemd patch reapplication snippet to ensure the refreshed hunk applies cleanly

------
https://chatgpt.com/codex/tasks/task_e_68cbeed4cd14832facac127af77a0372