### PR TITLE
Add arm64 virt EL2 Fiasco config to setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -553,6 +553,7 @@ check_tools()
 do_setup()
 {
   [ "$CONF_DO_ARM_VIRT_PL2" ] && fiasco_configs="$fiasco_configs arm-virt-pl2"
+  [ "$CONF_DO_ARM64_VIRT_EL2" ] && fiasco_configs="$fiasco_configs arm64-virt-el2"
 
   get_fiasco_dir()
   {


### PR DESCRIPTION
## Summary
- append the arm64-virt-el2 target to the generated Fiasco configs when CONF_DO_ARM64_VIRT_EL2 is enabled

## Testing
- gmake setup
- gmake build_images
