### PR TITLE
Update runqemu default image selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ scripts/docker_build.sh   # cross-compiles and places artifacts in out/
 After building, boot the image on your host with:
 
 ```bash
-scripts/runqemu.sh        # launches the default image from out/images/
+scripts/runqemu.sh        # launches bootstrap_hello_arm_virt.elf or the newest .elf image
 ```
 
 In case of issues with the Docker build container, run:

--- a/docs/build.md
+++ b/docs/build.md
@@ -46,6 +46,10 @@ To boot the built image on your host, run:
 scripts/runqemu.sh
 ```
 
+The helper prefers `out/images/bootstrap_hello_arm_virt.elf` when available and
+otherwise launches the most recently updated `.elf` image in `out/images/`. Pass
+an explicit path to boot a different artifact.
+
 ## Building for ARM
 
 Use `scripts/build.sh` to build the project. The script removes previous build
@@ -53,8 +57,10 @@ artifacts before compilation (the same effect as passing `--clean`). Provide
 `--no-clean` to skip this cleanup when iterating.
 
 Built components and images are collected under the `out/` directory. To boot
-an image on your host, run `scripts/runqemu.sh` and optionally pass the path to
-the desired image in `out/images/`.
+an image on your host, run `scripts/runqemu.sh`. The script automatically
+chooses a sensible default image (preferring
+`out/images/bootstrap_hello_arm_virt.elf`) but accepts a path to another image
+when provided.
 
 The build scripts store version markers alongside cross-compiled binaries (for
 example `out/bash/arm/VERSION`). When the version constants in `scripts/build.sh`

--- a/scripts/runqemu.sh
+++ b/scripts/runqemu.sh
@@ -3,6 +3,56 @@ set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
 REPO_ROOT="$SCRIPT_DIR/.."
+DEFAULT_IMAGE_DIR="$REPO_ROOT/out/images"
+DEFAULT_IMAGE_CANDIDATE="$DEFAULT_IMAGE_DIR/bootstrap_hello_arm_virt.elf"
 
-IMAGE_PATH="${1:-$REPO_ROOT/out/images/bootstrap_systemd_arm_virt.elf}"
+IMAGE_PATH="${1:-}"
+
+if [[ -z "$IMAGE_PATH" ]]; then
+  if [[ -f "$DEFAULT_IMAGE_CANDIDATE" ]]; then
+    IMAGE_PATH="$DEFAULT_IMAGE_CANDIDATE"
+  else
+    shopt -s nullglob
+    images=("$DEFAULT_IMAGE_DIR"/*.elf)
+    shopt -u nullglob
+
+    if (( ${#images[@]} == 0 )); then
+      echo "No bootable ELF image found under $DEFAULT_IMAGE_DIR." >&2
+      echo "Build the project first (e.g. run scripts/build.sh) or provide an image path." >&2
+      exit 1
+    fi
+
+    latest_image=""
+    latest_mtime=0
+    for candidate in "${images[@]}"; do
+      if ! mtime=$(stat -c %Y "$candidate" 2>/dev/null); then
+        if ! mtime=$(stat -f %m "$candidate" 2>/dev/null); then
+          continue
+        fi
+      fi
+
+      if (( mtime > latest_mtime )); then
+        latest_mtime=$mtime
+        latest_image="$candidate"
+      fi
+    done
+
+    if [[ -z "$latest_image" ]]; then
+      echo "Unable to determine a bootable ELF image under $DEFAULT_IMAGE_DIR." >&2
+      echo "Build the project first (e.g. run scripts/build.sh) or provide an image path." >&2
+      exit 1
+    fi
+
+    IMAGE_PATH="$latest_image"
+  fi
+fi
+
+if [[ ! -f "$IMAGE_PATH" ]]; then
+  echo "Image '$IMAGE_PATH' does not exist." >&2
+  echo "Build the project first (e.g. run scripts/build.sh) or provide a valid image path." >&2
+  exit 1
+fi
+
+echo "Launching image: $IMAGE_PATH"
+
 "$REPO_ROOT/src/l4/tool/bin/l4image" -i "$IMAGE_PATH" launch


### PR DESCRIPTION
## Summary
- prefer the bootstrap_hello ARM virt image when launching QEMU and fall back to the newest ELF in out/images
- surface actionable guidance when no ELF image is present
- document the updated default image selection across the README and build guide

## Testing
- not run (not requested)

