### PR TITLE
Stage all bootable images in build artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Pass `--clean` (the default) to force removal of previous build directories or
 `--no-clean` to reuse them for incremental builds. Build artifacts are placed
 under `out/`.
 
+All bootable `.elf` outputs—and any generated `.uimage` files—found under
+`obj/l4/*/images/` (including nested entry-point directories created from
+`.imagebuilds`) are staged into `out/images/`. When multiple images share a
+basename, the most recently built file wins so the latest
+`bootstrap_hello_arm_virt.elf` remains available without manual intervention.
+
 **Fallback**, to cross-compile inside a container, run:
 
 ```bash

--- a/docs/build.md
+++ b/docs/build.md
@@ -56,11 +56,14 @@ Use `scripts/build.sh` to build the project. The script removes previous build
 artifacts before compilation (the same effect as passing `--clean`). Provide
 `--no-clean` to skip this cleanup when iterating.
 
-Built components and images are collected under the `out/` directory. To boot
-an image on your host, run `scripts/runqemu.sh`. The script automatically
-chooses a sensible default image (preferring
-`out/images/bootstrap_hello_arm_virt.elf`) but accepts a path to another image
-when provided.
+Built components and images are collected under the `out/` directory. Every
+bootable `.elf` (and any generated `.uimage`) discovered under
+`obj/l4/*/images/`—including nested entry-point directories produced by
+`.imagebuilds`—is staged into `out/images/`, overwriting older copies when
+duplicates share a basename. To boot an image on your host, run
+`scripts/runqemu.sh`. The script automatically chooses a sensible default image
+(preferring `out/images/bootstrap_hello_arm_virt.elf`) but accepts a path to
+another image when provided.
 
 The build scripts store version markers alongside cross-compiled binaries (for
 example `out/bash/arm/VERSION`). When the version constants in `scripts/build.sh`


### PR DESCRIPTION
## Summary
- add a stage_bootable_images helper that gathers every .elf/.uimage under obj/l4/**/images and stages them into out/images
- copy candidates in timestamp order so the latest builds win when basenames collide and log each staged artifact
- document the broader staging behaviour in README.md and docs/build.md so helpers reference the expanded image set

## Testing
- ./scripts/build.sh --clean *(fails: proxy returned 403 while downloading upstream sources)*
- /tmp/run_stage.sh
- ./scripts/runqemu.sh || true
