### PR TITLE
Stage bootable images into distribution directory

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1277,9 +1277,10 @@ enable_service bash
 # Collect key build artifacts
 stage_bootable_images() {
   local source_root="obj/l4"
-  local dest_dir="$ARTIFACTS_DIR/images"
+  local distribution_dir="distribution"
+  local distribution_images_dir="$distribution_dir/images"
 
-  mkdir -p "$dest_dir"
+  mkdir -p "$distribution_images_dir"
 
   if [ ! -d "$source_root" ]; then
     return
@@ -1314,9 +1315,9 @@ stage_bootable_images() {
     file="${entry#*$'\t'}"
     [ -n "$file" ] || continue
     base="$(basename "$file")"
-    dest_path="$dest_dir/$base"
+    dest_path="$distribution_images_dir/$base"
 
-    echo "Staging image $base from $file"
+    echo "Staging image $base from $file into $distribution_images_dir"
     cp -f "$file" "$dest_path"
   done
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -748,7 +748,7 @@ case "$cmd" in
      ;;
   clean)
      do_clean
-     rm -rf out
+     rm -rf out distribution
      ;;
   *)
      echo "Call $0 [config|setup|clean|--non-interactive]"


### PR DESCRIPTION
## Summary
- stage collected bootable images into distribution/images instead of out/images
- update the setup clean path to remove the new distribution directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc671ea8f8832f9ad1fc80bd5dc73e