### PR TITLE
Refresh remove-libmount patch for systemd v255.4

### DIFF
--- a/scripts/patches/systemd/remove-libmount.patch
+++ b/scripts/patches/systemd/remove-libmount.patch
@@ -34,23 +34,24 @@ diff --git a/meson.build b/meson.build
 diff --git a/src/shared/libmount-util.h b/src/shared/libmount-util.h
 --- a/src/shared/libmount-util.h
 +++ b/src/shared/libmount-util.h
-@@ -2,10 +2,13 @@
+@@ -1,11 +1,14 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
  #pragma once
-
- /* This needs to be after sys/mount.h */
--#include <libmount.h> /* IWYU pragma: export */
+ 
+-/* This needs to be after sys/mount.h */
+-#include <libmount.h>
 +#include <stdio.h>
-
- #include "forward.h"
-
+ 
+ #include "macro.h"
+ 
 +#if HAVE_LIBMOUNT
++/* This needs to be after sys/mount.h */
 +#include <libmount.h> /* IWYU pragma: export */
 +
  DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(struct libmnt_table*, mnt_free_table, NULL);
  DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(struct libmnt_iter*, mnt_free_iter, NULL);
-
-@@ -35,3 +38,66 @@
- int libmount_is_leaf(
+ 
+@@ -18,3 +21,47 @@ int libmount_is_leaf(
                  struct libmnt_table *table,
                  struct libmnt_fs *fs);
 +
@@ -72,7 +73,7 @@ diff --git a/src/shared/libmount-util.h b/src/shared/libmount-util.h
 +DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(struct libmnt_table*, mnt_free_table, NULL);
 +DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(struct libmnt_iter*, mnt_free_iter, NULL);
 +
-+static inline int libmount_parse_full(
++static inline int libmount_parse(
 +                const char *path,
 +                FILE *source,
 +                struct libmnt_table **ret_table,
@@ -88,25 +89,6 @@ diff --git a/src/shared/libmount-util.h b/src/shared/libmount-util.h
 +        return -EOPNOTSUPP;
 +}
 +
-+static inline int libmount_parse_mountinfo(
-+                FILE *source,
-+                struct libmnt_table **ret_table,
-+                struct libmnt_iter **ret_iter) {
-+
-+        return libmount_parse_full("/proc/self/mountinfo", source, ret_table, ret_iter);
-+}
-+
-+static inline int libmount_parse_with_utab(
-+                struct libmnt_table **ret_table,
-+                struct libmnt_iter **ret_iter) {
-+
-+        return libmount_parse_full(NULL, NULL, ret_table, ret_iter);
-+}
-+
-+static inline int libmount_parse_fstab(struct libmnt_table **ret_table, struct libmnt_iter **ret_iter) {
-+        return libmount_parse_full(NULL, NULL, ret_table, ret_iter);
-+}
-+
 +static inline int libmount_is_leaf(
 +                struct libmnt_table *table,
 +                struct libmnt_fs *fs) {
@@ -116,6 +98,7 @@ diff --git a/src/shared/libmount-util.h b/src/shared/libmount-util.h
 +        return -EOPNOTSUPP;
 +}
 +#endif
+
 diff --git a/src/shared/meson.build b/src/shared/meson.build
 --- a/src/shared/meson.build
 +++ b/src/shared/meson.build


### PR DESCRIPTION
## Summary
- update the libmount-util.h hunk in remove-libmount.patch to match systemd v255.4
- provide inline stubs for libmount_parse/libmount_is_leaf when HAVE_LIBMOUNT is disabled

## Testing
- patch -p1 < remove-libmount.patch
