### PR TITLE
Update systemd libmount header stub guard

### DIFF
--- a/scripts/patches/systemd/remove-libmount.patch
+++ b/scripts/patches/systemd/remove-libmount.patch
@@ -51,10 +51,13 @@ diff --git a/src/shared/libmount-util.h b/src/shared/libmount-util.h
  DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(struct libmnt_table*, mnt_free_table, NULL);
  DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(struct libmnt_iter*, mnt_free_iter, NULL);
  
-@@ -18,3 +21,47 @@ int libmount_is_leaf(
-                 struct libmnt_table *table,
-                 struct libmnt_fs *fs);
-+
+@@ -18,3 +21,46 @@
+-int libmount_is_leaf(
+-                struct libmnt_table *table,
+-                struct libmnt_fs *fs);
++int libmount_is_leaf(
++                struct libmnt_table *table,
++                struct libmnt_fs *fs);
 +#else
 +#include <errno.h>
 +


### PR DESCRIPTION
## Summary
- refresh the libmount-util.h hunk in remove-libmount.patch to match systemd 255.4
- ensure libmount_parse and libmount_is_leaf stay inside the HAVE_LIBMOUNT guard when libmount is unavailable

## Testing
- Applied the refreshed patch to the systemd v255.4 source tree and inspected the generated header
- Compiled a small translation unit including libmount-util.h with HAVE_LIBMOUNT=0

------
https://chatgpt.com/codex/tasks/task_e_68ccd55d1118832fbdc5257e2d956142