### PR TITLE
Fix libcrypt detection and dependency injection

### DIFF
--- a/scripts/patches/systemd/disable-libcrypt.patch
+++ b/scripts/patches/systemd/disable-libcrypt.patch
@@ -3,14 +3,16 @@
 @@ -1013,9 +1013,11 @@
  libm = cc.find_library('m')
  libdl = cc.find_library('dl')
- libcrypt = dependency('libcrypt', 'libxcrypt', required : false)
+ libcrypt = dependency('libcrypt', required : false)
 -if not libcrypt.found()
++if not libcrypt.found()
++        libcrypt = dependency('libxcrypt', required : false)
++endif
 +libcrypt_found = libcrypt.found()
 +if not libcrypt_found
          # fallback to use find_library() if libcrypt is provided by glibc, e.g. for LibreELEC.
--        libcrypt = cc.find_library('crypt')
-+        libcrypt = cc.find_library('crypt', required : false)
-+        libcrypt_found = libcrypt.found()
+         libcrypt = cc.find_library('crypt', required : false)
+         libcrypt_found = libcrypt.found()
  endif
  libcap = dependency('libcap')
  
@@ -29,7 +31,7 @@
                    libzstd]
  
 +if libcrypt_found
-+        libshared_deps += libcrypt
++        libshared_deps += [libcrypt]
 +endif
 +
  libshared_sym_path = meson.current_source_dir() / 'libshared.sym'


### PR DESCRIPTION
## Summary
- rework the libcrypt detection logic to retry libxcrypt explicitly before falling back to a cc.find_library call and record the libcrypt_found flag for use in subdirs
- ensure libcrypt is re-added to libshared_deps when the library is available so libcrypt-util.c targets retain their dependency

## Testing
- PATH="$PWD/ham:$PATH" ./scripts/build.sh --no-clean *(fails: blocked by proxy when downloading prerequisites)*

------
https://chatgpt.com/codex/tasks/task_e_68cce2abe164832faa78cd710bc4afbb