### PR TITLE
Detect pkg-config for systemd build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -788,6 +788,15 @@ fi
 # Build systemd for ARM and ARM64
 build_systemd() {
   local arch="$1" cross="$2" expected_version="$3"
+  local pkg_config_bin=""
+  if command -v pkg-config >/dev/null 2>&1; then
+    pkg_config_bin="$(command -v pkg-config)"
+  elif command -v pkgconf >/dev/null 2>&1; then
+    pkg_config_bin="$(command -v pkgconf)"
+  else
+    echo "pkg-config not found; please install pkg-config or pkgconf" >&2
+    exit 1
+  fi
   local triple="$(${cross}g++ -dumpmachine)"
   if [[ "$triple" != *-linux-* ]]; then
     echo "${cross}g++ targets '$triple', but systemd requires a Linux-targeted toolchain" >&2
@@ -980,6 +989,7 @@ c = '${cross}gcc'
 cpp = '${cross}g++'
 ar = '${cross}ar'
 strip = '${cross}strip'
+pkgconfig = '${pkg_config_bin}'
 
 [host_machine]
 system = 'linux'


### PR DESCRIPTION
## Summary
- detect the available pkg-config implementation when building systemd, falling back to pkgconf if needed
- teach the generated Meson cross file to use the detected pkg-config binary so dependency discovery works reliably

## Testing
- PATH="$PWD/ham:$PATH" ./scripts/build.sh --clean *(fails: curl 56 CONNECT tunnel failed, response 403)*
