### PR TITLE
Add missing libmount stubs for swap helpers

### DIFF
--- a/scripts/patches/systemd/remove-libmount.patch
+++ b/scripts/patches/systemd/remove-libmount.patch
@@ -65,6 +65,29 @@ index 2f789e7..8bbce23 100644
 +struct libmnt_fs;
 +struct libmnt_monitor;
 +
++#define MNT_ITER_FORWARD 0
++#define MNT_ITER_BACKWARD 1
++
++static inline struct libmnt_table *mnt_new_table(void) {
++        errno = EOPNOTSUPP;
++        return NULL;
++}
++
++static inline struct libmnt_iter *mnt_new_iter(int direction) {
++        (void) direction;
++
++        errno = EOPNOTSUPP;
++        return NULL;
++}
++
++static inline int mnt_table_parse_swaps(struct libmnt_table *table, const char *path) {
++        (void) table;
++        (void) path;
++
++        errno = EOPNOTSUPP;
++        return -EOPNOTSUPP;
++}
++
 +static inline void mnt_free_table(struct libmnt_table *table) {
 +        (void) table;
 +}


### PR DESCRIPTION
## Summary
- add stub implementations for `mnt_new_table`, `mnt_new_iter`, and `mnt_table_parse_swaps` when libmount is unavailable
- define iterator constants for the stub branch and propagate `EOPNOTSUPP` through the new stubs

## Testing
- `gcc -std=gnu11 -Wall -Wextra -Werror=implicit-function-declaration -DHAVE_LIBMOUNT=0 -DRELATIVE_SOURCE_PATH=\"src\" -DSIZEOF_TIME_T=8 -DHAVE_REALLOCARRAY=1 -DBUILD_MODE_DEVELOPER=0 -I src -I src/basic -I src/shared -I src/shutdown -I src/fundamental -c src/shutdown/detach-swap.c -o /tmp/detach-swap.o`
