### PR TITLE
Fix libmount stub patch for systemd v255.4

### DIFF
--- a/scripts/patches/systemd/remove-libmount.patch
+++ b/scripts/patches/systemd/remove-libmount.patch
@@ -39,21 +39,21 @@ index 2f789e7..8bbce23 100644
 @@ -1,11 +1,14 @@
  /* SPDX-License-Identifier: LGPL-2.1-or-later */
  #pragma once
- 
+
 -/* This needs to be after sys/mount.h */
 -#include <libmount.h>
 +#include <stdio.h>
- 
+
  #include "macro.h"
- 
+
 +#if HAVE_LIBMOUNT
 +/* This needs to be after sys/mount.h */
 +#include <libmount.h> /* IWYU pragma: export */
 +
  DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(struct libmnt_table*, mnt_free_table, NULL);
  DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(struct libmnt_iter*, mnt_free_iter, NULL);
- 
-@@ -18,3 +21,146 @@ int libmount_parse(
+
+@@ -18,3 +21,170 @@ int libmount_parse(
  int libmount_is_leaf(
                  struct libmnt_table *table,
                  struct libmnt_fs *fs);
@@ -222,6 +222,7 @@ index 2f789e7..8bbce23 100644
 +        errno = EOPNOTSUPP;
 +        return -EOPNOTSUPP;
 +}
++
 +#endif /* HAVE_LIBMOUNT */
 diff --git a/src/shared/meson.build b/src/shared/meson.build
 index b24a541..1f92b84 100644


### PR DESCRIPTION
## Summary
- extend the libmount-util.h hunk in the remove-libmount patch so the libmount stubs now include mnt_monitor_get_fd(), mnt_monitor_next_change(), and the closing #endif guard
- keep the rest of the systemd patch intact so it continues to gate libmount-dependent sources
