### PR TITLE
Fix build_systemd cross file variable expansion

### DIFF
--- a/scripts/build_systemd.sh
+++ b/scripts/build_systemd.sh
@@ -268,7 +268,7 @@ mkdir -p "$out_dir"
   builddir="build-$arch"
   rm -rf "$builddir"
   mkdir -p "$builddir"
-  cat > cross.txt <<'CROSS_EOF'
+  cat > cross.txt <<CROSS_EOF
 [binaries]
 c = '${cross}gcc'
 cpp = '${cross}g++'


### PR DESCRIPTION
## Summary
- allow the build script to expand the cross toolchain variables when generating Meson's cross.txt so the real compiler names are written out

## Testing
- scripts/build_systemd.sh arm64 x86_64-linux-gnu- 255.4 /tmp/systemd *(fails later because gperf is missing, but Meson now recognizes the compilers and proceeds past the earlier error)*
