### PR TITLE
Add menu-controlled cleanup flag to build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,15 @@ scripts/build.sh          # builds natively
 CROSS_COMPILE=aarch64-linux-gnu- scripts/build.sh  # Override any aarch64-elf- default.
 ```
 
-Pass `--clean` (the default) to force removal of previous build directories or
-`--no-clean` to reuse them for incremental builds. Build artifacts are placed
-under `out/`.
+Pass `--clean` (or select “Clean out directory before build” in the interactive
+menu) to remove previous build directories. By default the script reuses
+existing directories for incremental builds; `--no-clean` enforces this reuse in
+automation. Build artifacts are placed under `out/`.
 
 When `dialog` is available the script shows an interactive checklist of
-external components (Bash, libcap, systemd, etc.) to build. Choose the desired
-entries or pass `--no-menu` (and optionally `--components=foo,bar`) to skip the
-prompt in automation.
+external components (Bash, libcap, systemd, etc.) to build along with a follow-
+up prompt to request cleanup. Choose the desired entries or pass `--no-menu`
+(and optionally `--components=foo,bar`) to skip the prompts in automation.
 
 At the end of the run the script prints a summary table enumerating each
 external component as `success`, `skipped`, or `failed`. A non-zero exit status

--- a/docs/build.md
+++ b/docs/build.md
@@ -52,9 +52,11 @@ an explicit path to boot a different artifact.
 
 ## Building for ARM
 
-Use `scripts/build.sh` to build the project. The script removes previous build
-artifacts before compilation (the same effect as passing `--clean`). Provide
-`--no-clean` to skip this cleanup when iterating.
+Use `scripts/build.sh` to build the project. By default the script reuses
+previous build artifacts so incremental builds are faster. Pass `--clean` (or
+select “Clean out directory before build” in the interactive menu) to remove old
+artifacts before compilation, and use `--no-clean` to explicitly request reuse
+in automation.
 
 Built components and images are collected under the `out/` directory. Every
 bootable `.elf` (and any generated `.uimage`) discovered under


### PR DESCRIPTION
## Summary
- default the build script to reuse build directories unless cleanup is explicitly requested
- add an interactive dialog prompt to request cleanup and respect CLI overrides, including updated status messaging
- document the new behavior in the usage text, README, and build documentation

## Testing
- bash -n scripts/build.sh
