### PR TITLE
Add dialog-driven driver picker workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "dialoguer",
  "regex",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "walkdir",
@@ -711,6 +712,18 @@ dependencies = [
  "proc-macro2 1.0.101",
  "quote 1.0.40",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ Guidance on required cross-compilers and environment setup is in [docs/toolchain
 macOS-specific toolchain setup is covered in [docs/toolchains.md](docs/toolchains.md).
 
 ### Driver packaging workflow
+See [docs/driver-packaging.md](docs/driver-packaging.md) for the end-to-end
+packaging flow. The menu-based helper described there depends on the external
+`dialog` utility, falling back to plain prompts when the binary is unavailable.
 Details on packaging drivers for L4Re are provided in [docs/driver-packaging.md](docs/driver-packaging.md).
 
 ### Systemd integration

--- a/docs/driver-packaging.md
+++ b/docs/driver-packaging.md
@@ -11,9 +11,37 @@ consumed by the L4Re build system.
 tools/l4re-driver-wrap --linux-src /path/to/linux
 ```
 
-The script launches an interactive selector to choose a driver from the Linux
-source tree. After extraction, the driver is wrapped and a package directory is
-created.
+When invoked from an interactive terminal with the external
+[`dialog`](https://invisible-island.net/dialog/dialog.html) utility available,
+the wrapper launches `tools/driver_picker_menu.sh`. The helper gathers the
+catalog via `driver_picker --list`, presents a menu to select a subsystem and a
+driver, and finally runs the extraction pipeline with
+`driver_picker --driver <symbol> --subsystem <name>`. The resulting output still
+mirrors the traditional format:
+
+```
+Workspace: /tmp/l4re-driver.XXXXXX
+Manifest written to /tmp/l4re-driver.XXXXXX/driver.yaml
+```
+
+If `dialog` is missing or the session is non-interactive the workflow falls back
+to the original `cargo run -p driver_picker` prompts.
+
+To preview the available drivers without extracting anything, run:
+
+```
+cargo run -p driver_picker -- --linux-src /path/to/linux --list --format json
+```
+
+The picker can also operate non-interactively when both the subsystem and
+driver are known ahead of time:
+
+```
+cargo run -p driver_picker -- \
+  --linux-src /path/to/linux \
+  --subsystem net \
+  --driver E1000
+```
 
 ## Using a configuration file
 
@@ -35,7 +63,8 @@ generated manifest is used.
 ## Troubleshooting
 
 * Ensure the `tools/driver_picker` tool builds successfully and that `LINUX_SRC`
-  points to a valid kernel tree.
+  points to a valid kernel tree. Installing `dialog` enables the menu-based
+  picker used by `tools/l4re-driver-wrap` and `tools/driver_picker_menu.sh`.
 * If compilation fails, verify that cross-compilation toolchains referenced by
   the `CROSS_COMPILE` environment variable are installed.
 * Packaging errors usually indicate the build step did not produce the expected

--- a/tools/driver_picker/Cargo.toml
+++ b/tools/driver_picker/Cargo.toml
@@ -11,4 +11,5 @@ dialoguer = "0.10"
 tempfile = "3"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
+serde_json = "1"
 anyhow = "1"

--- a/tools/driver_picker_menu.sh
+++ b/tools/driver_picker_menu.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+if ! command -v dialog >/dev/null 2>&1; then
+  echo "Error: the 'dialog' binary is required for the menu workflow." >&2
+  exit 1
+fi
+
+run_driver_picker() {
+  if command -v driver_picker >/dev/null 2>&1; then
+    driver_picker "$@"
+  else
+    cargo run --quiet --manifest-path "$SCRIPT_DIR/driver_picker/Cargo.toml" -- "$@"
+  fi
+}
+
+orig_args=("$@")
+filtered_args=()
+i=0
+while [[ $i -lt ${#orig_args[@]} ]]; do
+  arg=${orig_args[$i]}
+  case "$arg" in
+    --driver|--subsystem|--format)
+      opt="$arg"
+      ((i++))
+      if [[ $i -ge ${#orig_args[@]} ]]; then
+        echo "Missing value for $opt" >&2
+        exit 1
+      fi
+      ((i++))
+      ;;
+    --driver=*|--subsystem=*|--format=*|--list|--list=*)
+      ((i++))
+      ;;
+    *)
+      filtered_args+=("$arg")
+      ((i++))
+      ;;
+  esac
+done
+
+catalog=$(run_driver_picker --list --format tsv "${filtered_args[@]}")
+if [[ -z "$catalog" ]]; then
+  echo "No drivers discovered in the provided Linux source tree." >&2
+  exit 1
+fi
+
+declare -A driver_map=()
+declare -A subsystem_counts=()
+subsystems=()
+while IFS=$'\t' read -r subsystem driver; do
+  [[ -z "$subsystem" || -z "$driver" ]] && continue
+  if [[ -v driver_map["$subsystem"] ]]; then
+    driver_map["$subsystem"]+=$'\n'"$driver"
+  else
+    driver_map["$subsystem"]="$driver"
+    subsystems+=("$subsystem")
+  fi
+  count=${subsystem_counts["$subsystem"]:-0}
+  subsystem_counts["$subsystem"]=$((count + 1))
+done <<<"$catalog"
+
+if [[ ${#subsystems[@]} -eq 0 ]]; then
+  echo "No drivers discovered in the provided Linux source tree." >&2
+  exit 1
+fi
+
+IFS=$'\n' subsystems=($(printf '%s\n' "${subsystems[@]}" | sort))
+unset IFS
+
+tmp_subsystem=$(mktemp)
+tmp_driver=$(mktemp)
+trap 'rm -f "$tmp_subsystem" "$tmp_driver"' EXIT
+
+subsystem_menu=()
+for subsystem in "${subsystems[@]}"; do
+  count=${subsystem_counts["$subsystem"]}
+  plural="driver"
+  [[ $count -ne 1 ]] && plural="drivers"
+  subsystem_menu+=("$subsystem" "$count $plural")
+done
+
+if ! dialog --clear --menu "Select subsystem" 20 70 15 "${subsystem_menu[@]}" 2>"$tmp_subsystem"; then
+  status=$?
+  if [[ $status -eq 1 || $status -eq 255 ]]; then
+    echo "Selection cancelled." >&2
+  fi
+  exit $status
+fi
+selected_subsystem=$(<"$tmp_subsystem")
+
+drivers_string=${driver_map["$selected_subsystem"]}
+mapfile -t drivers < <(printf '%s\n' "$drivers_string" | sort)
+
+driver_menu=()
+for driver in "${drivers[@]}"; do
+  driver_menu+=("$driver" "Linux config symbol")
+done
+
+if ! dialog --clear --menu "Select driver" 20 70 15 "${driver_menu[@]}" 2>"$tmp_driver"; then
+  status=$?
+  if [[ $status -eq 1 || $status -eq 255 ]]; then
+    echo "Selection cancelled." >&2
+  fi
+  exit $status
+fi
+selected_driver=$(<"$tmp_driver")
+
+run_driver_picker --driver "$selected_driver" --subsystem "$selected_subsystem" "${filtered_args[@]}"

--- a/tools/l4re-driver-wrap
+++ b/tools/l4re-driver-wrap
@@ -59,7 +59,11 @@ if [[ -z "${LINUX_SRC:-}" ]]; then
 fi
 
 # Step 1: run driver_picker selection/extraction tool
-picker_output=$(cargo run --manifest-path tools/driver_picker/Cargo.toml -- --linux-src "$LINUX_SRC")
+if [[ -t 0 && -t 1 ]] && command -v dialog >/dev/null 2>&1; then
+  picker_output=$(tools/driver_picker_menu.sh --linux-src "$LINUX_SRC")
+else
+  picker_output=$(cargo run --manifest-path tools/driver_picker/Cargo.toml -- --linux-src "$LINUX_SRC")
+fi
 echo "$picker_output"
 workspace=$(echo "$picker_output" | sed -n 's/^Workspace: //p' | tail -n1)
 manifest="$workspace/driver.yaml"


### PR DESCRIPTION
## Summary
- extend `tools/driver_picker` with catalog listing, non-interactive selection, and JSON/TSV output options
- add `tools/driver_picker_menu.sh` and update `tools/l4re-driver-wrap` to offer a dialog-based menu when available
- document the new workflow and dialog dependency in README and driver packaging guide

## Testing
- cargo fmt
- cargo check -p driver_picker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Menu-driven driver selection when a dialog utility is available; gracefully falls back to prompts or standard non-interactive flow.
  * Non-interactive usage: list available drivers, filter by subsystem, and select a driver directly via flags.
  * Catalog output available in TSV (default) or JSON.

* **Documentation**
  * Expanded driver packaging guide with end-to-end workflow, interactive vs non-interactive paths, examples, and troubleshooting.
  * README links to the guide and clarifies behavior notes, including L4Re packaging details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->