### PR TITLE
Fix systemd staging copy

### DIFF
--- a/scripts/build_systemd.sh
+++ b/scripts/build_systemd.sh
@@ -340,7 +340,7 @@ CROSS_EOF
   meson setup "${meson_setup_args[@]}"
   ninja -C "$builddir" systemd || ninja -C "$builddir"
   DESTDIR="$out_dir/root" meson install -C "$builddir"
-  cp "$out_dir/root/" "$out_dir/"
+  cp -a "$out_dir/root/." "$out_dir/"
 )
 
 echo "$expected_version" > "$out_dir/VERSION"


### PR DESCRIPTION
## Summary
- ensure the systemd build uses a recursive cp -a when staging the installation tree

## Testing
- scripts/build_systemd.sh arm /tmp/host-cross/bin/host-cross- 999.0 /tmp/fake-systemd

