### PR TITLE
Support configurable make targets in build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,22 @@ BASH_ARCHES := arm arm64
 bash-image: $(addprefix obj/bash/,$(addsuffix /bash,$(BASH_ARCHES))) build_images
 
 obj/bash/%/bash:
-	@scripts/build.sh --no-clean
+	@if [ -z "$$BUILD_SH_INVOKED" ]; then \
+		scripts/build.sh --no-clean; \
+	else \
+		echo "BUILD_SH_INVOKED set; skipping scripts/build.sh for $@"; \
+	fi
 
 SYSTEMD_ARCHES := arm arm64
 
 systemd-image: $(addprefix obj/systemd/,$(addsuffix /systemd,$(SYSTEMD_ARCHES))) build_images
 
 obj/systemd/%/systemd:
-	@scripts/build.sh --no-clean
+	@if [ -z "$$BUILD_SH_INVOKED" ]; then \
+		scripts/build.sh --no-clean; \
+	else \
+		echo "BUILD_SH_INVOKED set; skipping scripts/build.sh for $@"; \
+	fi
 
 EXAMPLE_CRATES := \
 src/fs_server \


### PR DESCRIPTION
## Summary
- add metadata and CLI parsing for selectable top-level make targets in `scripts/build.sh`
- run selected make targets via a new helper, defaulting to `all`, and only proceed with post-build staging when `all` succeeds
- guard recursive make invocations by exporting `BUILD_SH_INVOKED` and updating make recipes to skip re-entering the build script

## Testing
- ./scripts/build.sh --help


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Choose specific build targets via a new command-line option.
  - Per-target results and notes are shown in an expanded build summary.
  - Sensible defaults: all targets run when none are specified.

- Bug Fixes
  - Prevents duplicate build script execution during nested builds.

- Documentation
  - Help/usage updated to list available targets and the new selection option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->