### PR TITLE
Default builds to systemd image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-all: 
+all:
 	@if [ -d obj ]; then                                           \
-	  $(MAKE) build_all;                                           \
+	  $(MAKE) systemd-image;                                       \
 	else                                                           \
-          echo "Call 'gmake setup' once for initial setup." ;           \
+	  echo "Call 'gmake setup' once for initial setup." ;           \
 	  exit 1;                                                      \
 	fi
 
@@ -130,12 +130,12 @@ pre-built-images/l4image:
 
 help:
 	@echo "Targets:"
-	@echo "  all"
-	@echo "  setup"
-	@echo "  gen_prebuilt"
-	@echo "  bash-image    Build image with Bash as first program"
-	@echo "  systemd-image Build image with systemd"
-	@echo "  examples      Build Rust example servers and clients"
+	@echo "  systemd-image (default) Build image with systemd"
+	@echo "  all                      Alias for systemd-image"
+	@echo "  setup                    Prepare the source tree"
+	@echo "  gen_prebuilt             Generate pre-built images"
+	@echo "  bash-image               Build image with Bash as first program"
+	@echo "  examples                 Build Rust example servers and clients"
 .PHONY: setup all build_all clean help \
 build_images build_fiasco build_l4re bash-image \
 systemd-image examples

--- a/README.md
+++ b/README.md
@@ -54,11 +54,17 @@ when developing locally to ensure `l4re-core` is up to date.
 
 ## Standard Build
 
+After running `gmake setup` once to initialize the tree, invoking `gmake`
+without arguments now builds the `systemd-image` target. This produces a
+systemd-based boot image and serves as the primary build configuration. Other
+gmake targets remain available—run them explicitly (for example,
+`gmake bash-image` or `gmake examples`) when you need alternative outputs.
+
 On a host with the necessary prerequisites installed, run:
 
 **Linux:**
 ```bash
-scripts/build.sh          # builds natively
+scripts/build.sh          # builds the systemd image natively
 ```
 
 **Mac:**
@@ -72,10 +78,13 @@ existing directories for incremental builds; `--no-clean` enforces this reuse in
 automation. Build artifacts are placed under `out/`.
 
 When `dialog` is available the script shows interactive checklists covering the
-external components (Bash, libcap, systemd, etc.) to build and the make targets
-to invoke, followed by a cleanup prompt. Choose the desired entries or pass
-`--no-menu` (and optionally `--components=foo,bar` and
-`--make-targets=target1,target2`) to skip the prompts in automation.
+external components (Bash, libcap, systemd, etc.) to build and the make target
+to invoke, followed by a cleanup prompt. The make-target list is now limited to
+the systemd image and defaults to that selection. Choose the desired entries or
+pass `--no-menu` (and optionally `--components=foo,bar`) to skip the prompts in
+automation. To invoke other make targets, call `gmake <target>` directly after
+the script completes or run the desired target via `gmake` without using the
+menu.
 
 At the end of the run the script prints summary tables enumerating each
 external component and make target as `success`, `skipped`, or `failed`. A

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -97,23 +97,11 @@ declare -A BUILD_COMPONENT_LABELS=(
 )
 
 readonly -a MAKE_TARGET_IDS=(
-  all
-  clean
-  setup
-  bash-image
   systemd-image
-  examples
-  gen_prebuilt
 )
 
 declare -A MAKE_TARGET_LABELS=(
-  [all]="Build the entire project"
-  [clean]="Remove previous build outputs"
-  [setup]="Run the initial project setup"
-  [bash-image]="Build image with Bash as first program"
   [systemd-image]="Build image with systemd"
-  [examples]="Build Rust example servers and clients"
-  [gen_prebuilt]="Generate pre-built images"
 )
 
 run_component_build() {
@@ -329,7 +317,7 @@ prompt_component_selection() {
   local default_state
   for target in "${MAKE_TARGET_IDS[@]}"; do
     default_state="off"
-    if [ "$target" = "all" ]; then
+    if [ "$target" = "systemd-image" ]; then
       default_state="on"
     fi
     target_menu_args+=("$target" "${MAKE_TARGET_LABELS[$target]}" "$default_state")
@@ -572,7 +560,7 @@ if [ ${#selected_make_targets[@]} -eq 0 ]; then
   if [ "$explicit_make_target_selection" = true ]; then
     :
   else
-    selected_make_targets=(all)
+    selected_make_targets=(systemd-image)
   fi
 fi
 


### PR DESCRIPTION
## Summary
- make `gmake` default to the `systemd-image` target and update help text to highlight it
- streamline `scripts/build.sh` so the interactive menu only offers the systemd image and defaults to it
- document the new default systemd build and how to invoke other targets explicitly

## Testing
- scripts/build.sh --no-menu --components= --make-targets=systemd-image *(fails: missing Git::Repository perl module)*
- gmake *(fails: repository not yet bootstrapped)*

