### PR TITLE
Fix default CC selection in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -77,7 +77,7 @@ if [ "$cmd" != "clean" ] && [ "$non_interactive" -eq 0 ]; then
 fi
 
 export CROSS_COMPILE=${CROSS_COMPILE:-}
-CC=${CC:-${CROSS_COMPILE}g++}
+CC=${CC:-${CROSS_COMPILE}gcc}
 CXX=${CXX:-${CROSS_COMPILE}g++}
 LD=${LD:-${CROSS_COMPILE}ld}
 


### PR DESCRIPTION
## Summary
- set the setup script's default CC to use the gcc frontend when a CROSS_COMPILE prefix is present while leaving the default CXX unchanged

## Testing
- scripts/setup.sh --non-interactive *(fails: environment lacks the pre-fetched L4 build tree, so gmake stops with "No targets specified and no makefile found")*
