### PR TITLE
Fix Makefile systemd targets to match build outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,17 @@ obj/bash/%/bash:
 	fi
 
 SYSTEMD_ARCHES := arm arm64
+SYSTEMD_OUTPUTS := $(addprefix out/systemd/,$(addsuffix /lib/systemd/systemd,$(SYSTEMD_ARCHES)))
 
-systemd-image: $(addprefix obj/systemd/,$(addsuffix /systemd,$(SYSTEMD_ARCHES))) build_images
+systemd-image: systemd-external $(SYSTEMD_OUTPUTS) build_images
 
-obj/systemd/%/systemd:
+$(SYSTEMD_OUTPUTS): systemd-external
+	@if [ ! -f "$@" ]; then \
+		echo "Missing expected systemd binary $@ after external build"; \
+		exit 1; \
+	fi
+
+systemd-external:
 	@if [ -z "$$BUILD_SH_INVOKED" ]; then \
 		scripts/build.sh --no-clean; \
 	else \
@@ -138,4 +145,4 @@ help:
 	@echo "  examples                 Build Rust example servers and clients"
 .PHONY: setup all build_all clean help \
 build_images build_fiasco build_l4re bash-image \
-systemd-image examples
+systemd-image systemd-external examples

--- a/pkg/systemd/Makefile
+++ b/pkg/systemd/Makefile
@@ -2,7 +2,7 @@ PKGDIR ?= .
 L4DIR ?= $(PKGDIR)/../..
 
 TARGET := systemd
-SYSTEMD_BIN := $(PKGDIR)/../../obj/systemd/$(L4ARCH)/systemd
+SYSTEMD_BIN := $(PKGDIR)/../../out/systemd/$(L4ARCH)/lib/systemd/systemd
 
 $(TARGET): $(SYSTEMD_BIN)
 	ln -sf $(SYSTEMD_BIN) $(TARGET)


### PR DESCRIPTION
## Summary
- update the systemd-image target to depend on the binaries produced under out/systemd
- add a dedicated phony target for invoking scripts/build.sh and validate that the expected binaries exist
- point the systemd package to the staged systemd binary in out/systemd/<arch>/lib/systemd

## Testing
- make -n systemd-image

------
https://chatgpt.com/codex/tasks/task_e_68cf0a678dc8832fa8ab5dc6a02b0ad3