### PR TITLE
Improve ham bootstrap and non-interactive setup flow

### DIFF
--- a/scripts/setup_l4re_env.sh
+++ b/scripts/setup_l4re_env.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -euo pipefail
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+else
+  set -eo pipefail
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=common_build.sh
@@ -21,20 +26,56 @@ if [ ! -x "$HAM_BIN" ]; then
   fi
 fi
 
-# The ham build from source depends on Perl modules that might not be available
-# in minimal environments. Fall back to the official prebuilt binary if the
-# required modules are missing so the script would not run successfully.
-if ! perl -MGit::Repository -e1 >/dev/null 2>&1; then
-  echo "Perl module Git::Repository missing, downloading prebuilt ham binary..."
-  tmp_bin="${HAM_BIN}.tmp"
-  if curl -fsSL "https://github.com/kernkonzept/ham/releases/latest/download/ham" -o "$tmp_bin"; then
-    mv "$tmp_bin" "$HAM_BIN"
-    chmod +x "$HAM_BIN"
-  else
-    rm -f "$tmp_bin"
-    echo "Failed to download prebuilt ham. Install the Perl dependency 'Git::Repository' and rerun setup." >&2
+# Ensure the Perl dependencies required by ham are available. If Git::Repository
+# is missing we bootstrap a local installation using cpanminus so that the
+# script can continue without requiring system-wide package management tools.
+ensure_perl_module() {
+  local module=$1
+
+  if perl "-M${module}" -e1 >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local cpanm="$HAM_PATH/cpanm"
+  local perl_lib="$HAM_PATH/perl5"
+
+  echo "Perl module ${module} missing, installing locally via cpanm..."
+
+  if [ ! -x "$cpanm" ]; then
+    if ! curl -fsSL "https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm" -o "$cpanm"; then
+      echo "Failed to download cpanm helper required to install Perl modules." >&2
+      return 1
+    fi
+    chmod +x "$cpanm"
+  fi
+
+  mkdir -p "$perl_lib"
+
+  if ! "$cpanm" --quiet --notest --local-lib "$perl_lib" "$module"; then
+    echo "cpanm failed to install Perl module ${module}." >&2
+    return 1
+  fi
+
+  export PERL5LIB="$perl_lib/lib/perl5${PERL5LIB:+:$PERL5LIB}"
+  export PATH="$perl_lib/bin${PATH:+:$PATH}"
+  export PERL_LOCAL_LIB_ROOT="$perl_lib${PERL_LOCAL_LIB_ROOT:+:$PERL_LOCAL_LIB_ROOT}"
+  export PERL_MB_OPT="--install_base '$perl_lib'"
+  export PERL_MM_OPT="INSTALL_BASE=$perl_lib"
+
+  if perl "-M${module}" -e1 >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "Perl module ${module} still unavailable after installation attempt." >&2
+  return 1
+}
+
+for module in Git::Repository XML::Parser; do
+  if ! ensure_perl_module "$module"; then
+    echo "Failed to provision Perl dependency $module automatically."
+    echo "Install it manually (e.g. via your package manager or CPAN) and rerun setup." >&2
     exit 1
   fi
-fi
+done
 
 chmod +x "$HAM_BIN"


### PR DESCRIPTION
## Summary
- bootstrap the ham Perl dependencies locally with a vendored cpanm download and ensure they load when sourced
- source the environment helper from setup.sh, fall back to default targets when dialog is missing, and avoid interactive prompts

## Testing
- `gmake setup` *(fails: missing cross-compilers such as arm-linux-gnueabihf-gcc in the container)*
