### PR TITLE
Update runqemu default image detection

### DIFF
--- a/scripts/runqemu.sh
+++ b/scripts/runqemu.sh
@@ -4,12 +4,49 @@ set -euo pipefail
 SCRIPT_DIR="$(dirname "$0")"
 REPO_ROOT="$SCRIPT_DIR/.."
 DEFAULT_IMAGE_DIR="$REPO_ROOT/distribution"
-DEFAULT_IMAGE_CANDIDATE="$DEFAULT_IMAGE_DIR/images/bootstrap_vm-basic.uimage"
+
+select_latest_image() {
+  local latest_image=""
+  local latest_mtime=0
+  local candidate mtime
+
+  for candidate in "$@"; do
+    if [[ ! -e "$candidate" ]]; then
+      continue
+    fi
+
+    if ! mtime=$(stat -c %Y "$candidate" 2>/dev/null); then
+      if ! mtime=$(stat -f %m "$candidate" 2>/dev/null); then
+        continue
+      fi
+    fi
+
+    if (( mtime > latest_mtime )); then
+      latest_mtime=$mtime
+      latest_image="$candidate"
+    fi
+  done
+
+  if [[ -z "$latest_image" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "$latest_image"
+}
+
+shopt -s nullglob
+bootstrap_images=("$DEFAULT_IMAGE_DIR"/images/bootstrap_vm-basic_*arm_virt*.uimage)
+shopt -u nullglob
+
+DEFAULT_IMAGE_CANDIDATE=""
+if latest_bootstrap=$(select_latest_image "${bootstrap_images[@]}"); then
+  DEFAULT_IMAGE_CANDIDATE="$latest_bootstrap"
+fi
 
 IMAGE_PATH="${1:-}"
 
 if [[ -z "$IMAGE_PATH" ]]; then
-  if [[ -f "$DEFAULT_IMAGE_CANDIDATE" ]]; then
+  if [[ -n "$DEFAULT_IMAGE_CANDIDATE" && -f "$DEFAULT_IMAGE_CANDIDATE" ]]; then
     IMAGE_PATH="$DEFAULT_IMAGE_CANDIDATE"
   else
     shopt -s nullglob
@@ -22,22 +59,7 @@ if [[ -z "$IMAGE_PATH" ]]; then
       exit 1
     fi
 
-    latest_image=""
-    latest_mtime=0
-    for candidate in "${images[@]}"; do
-      if ! mtime=$(stat -c %Y "$candidate" 2>/dev/null); then
-        if ! mtime=$(stat -f %m "$candidate" 2>/dev/null); then
-          continue
-        fi
-      fi
-
-      if (( mtime > latest_mtime )); then
-        latest_mtime=$mtime
-        latest_image="$candidate"
-      fi
-    done
-
-    if [[ -z "$latest_image" ]]; then
+    if ! latest_image=$(select_latest_image "${images[@]}"); then
       echo "Unable to determine a bootable ELF or U-Boot image under $DEFAULT_IMAGE_DIR/images." >&2
       echo "Build the project first (e.g. run scripts/build.sh) or provide an image path." >&2
       exit 1


### PR DESCRIPTION
## Summary
- add a reusable helper to select the newest image by modification time
- prefer bootstrap files with the new `_arm_virt` suffix when picking the default runqemu image
- reuse the helper for the generic fallback search so behaviour stays consistent when the preferred file is absent

## Testing
- `scripts/build.sh --clean`
- `scripts/runqemu.sh`
