### PR TITLE
Link l4re-libc against staged glibc

### DIFF
--- a/crates/l4re-libc/Cargo.toml
+++ b/crates/l4re-libc/Cargo.toml
@@ -8,6 +8,10 @@ build = "build.rs"
 name = "l4re_libc"
 crate-type = ["rlib", "staticlib"]
 
+[features]
+default = []
+syscall-fallbacks = []
+
 [build-dependencies]
 cc = "1.0"
 

--- a/crates/l4re-libc/build.rs
+++ b/crates/l4re-libc/build.rs
@@ -1,4 +1,19 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+const GLIBC_LIBS: &[&str] = &["c", "pthread", "dl", "m", "rt", "resolv", "crypt", "util"];
+
 fn main() {
+    if env::var_os("CARGO_FEATURE_SYSCALL_FALLBACKS").is_some() {
+        compile_syscall_wrappers();
+    }
+
+    configure_glibc_linkage();
+}
+
+fn compile_syscall_wrappers() {
     let mut build = cc::Build::new();
     build.include("include");
     build.file("src/epoll.c");
@@ -7,4 +22,83 @@ fn main() {
     build.file("src/timerfd.c");
     build.file("src/inotify.c");
     build.compile("l4re_libc_c");
+}
+
+fn configure_glibc_linkage() {
+    let prefix = resolve_glibc_prefix();
+    let lib_dir = prefix.join("lib");
+    if !lib_dir.is_dir() {
+        panic!(
+            "glibc prefix '{}' does not contain a 'lib' directory",
+            prefix.display()
+        );
+    }
+
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    for lib in GLIBC_LIBS {
+        println!("cargo:rustc-link-lib={}", lib);
+    }
+}
+
+fn resolve_glibc_prefix() -> PathBuf {
+    let manifest_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "unknown".to_string());
+
+    let mut env_candidates = Vec::new();
+    let arch_upper = target_arch.to_uppercase();
+    env_candidates.push(format!("L4RE_LIBC_GLIBC_PREFIX_{}", arch_upper));
+    match target_arch.as_str() {
+        "aarch64" => env_candidates.push("L4RE_LIBC_GLIBC_PREFIX_ARM64".to_string()),
+        "arm" => env_candidates.push("L4RE_LIBC_GLIBC_PREFIX_ARM".to_string()),
+        _ => {}
+    }
+    env_candidates.push("L4RE_LIBC_GLIBC_PREFIX".to_string());
+
+    for var in &env_candidates {
+        println!("cargo:rerun-if-env-changed={}", var);
+    }
+
+    for var in env_candidates {
+        if let Ok(value) = env::var(&var) {
+            let path = Path::new(&value);
+            if path.exists() {
+                return canonicalize(path);
+            }
+        }
+    }
+
+    let stage_arch = match target_arch.as_str() {
+        "aarch64" => "arm64",
+        "arm" => "arm",
+        other => other,
+    };
+
+    let default_prefix = manifest_dir
+        .join("..")
+        .join("..")
+        .join("out")
+        .join("glibc")
+        .join(stage_arch);
+    if default_prefix.exists() {
+        return canonicalize(&default_prefix);
+    }
+
+    panic!(
+        "Unable to locate glibc staging prefix for target arch '{}'. \
+Set L4RE_LIBC_GLIBC_PREFIX or L4RE_LIBC_GLIBC_PREFIX_{} to the staged glibc directory.",
+        target_arch,
+        arch_uppercase_fallback(&target_arch)
+    );
+}
+
+fn canonicalize(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn arch_uppercase_fallback(target_arch: &str) -> String {
+    match target_arch {
+        "aarch64" => "ARM64".to_string(),
+        other => other.to_uppercase(),
+    }
 }

--- a/crates/l4re-libc/tests/glibc_smoke.rs
+++ b/crates/l4re-libc/tests/glibc_smoke.rs
@@ -1,0 +1,27 @@
+use libc::{self, c_void};
+use std::{ffi::CString, mem, ptr};
+
+#[test]
+fn dlsym_resolves_eventfd() {
+    unsafe {
+        // Use a known libc symbol to validate the staged glibc can be loaded.
+        let handle = libc::dlopen(ptr::null(), libc::RTLD_NOW);
+        assert!(!handle.is_null(), "dlopen(NULL) returned NULL");
+
+        let symbol = CString::new("eventfd").expect("symbol name");
+        let sym = libc::dlsym(handle, symbol.as_ptr());
+        assert!(
+            !sym.is_null(),
+            "dlsym failed to locate eventfd symbol via staged glibc"
+        );
+
+        // Touch the symbol via an indirect call to ensure it can be invoked.
+        let func: unsafe extern "C" fn(libc::c_uint, libc::c_int) -> libc::c_int =
+            mem::transmute::<*mut c_void, _>(sym);
+        let fd = func(0, 0);
+        assert!(fd >= 0, "eventfd call via dlsym returned an error");
+        libc::close(fd);
+
+        libc::dlclose(handle);
+    }
+}


### PR DESCRIPTION
## Summary
- add a feature gate for the syscall-based fallbacks and switch the default build to call glibc directly
- teach the l4re-libc build script to locate the staged glibc tree, add the required link search paths, and link against the expected glibc libraries
- extend scripts/build.sh to stage glibc before building the Rust crate, expose the staging prefix via environment variables, and ensure LIBRARY_PATH/LD_LIBRARY_PATH include the staged libraries during cargo builds
- add a dlsym-based smoke test that exercises the staged glibc at runtime

## Testing
- cargo test -p l4re-libc


------
https://chatgpt.com/codex/tasks/task_e_68d00bed9a80832f93aa89b767c101de