### PR TITLE
Avoid conflicting stdio devices in QEMU setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -463,12 +463,26 @@ add_gen()
   Makeconf_added_gen+=("$1")
 }
 
+append_qemu_option()
+{
+  local file="$1"
+  local option="$2"
+
+  if [ -f "$file" ] && grep -F -q -- "$option" "$file"; then
+    return
+  fi
+
+  echo "QEMU_OPTIONS += $option" >> "$file"
+}
+
 add_std_qemu_options()
 {
   for f in "${Makeconf_added_qemu_std[@]}"; do
     [ "$f" = "$1" ] && { add_gen "$1"; return; }
   done
-  echo "QEMU_OPTIONS += -nographic" >> "$1"
+  append_qemu_option "$1" "-display none"
+  append_qemu_option "$1" "-serial stdio"
+  append_qemu_option "$1" "-monitor none"
   Makeconf_added_qemu_std+=("$1")
 
   add_gen "$1"


### PR DESCRIPTION
## Summary
- add a helper that appends QEMU options only when they are not already present in the generated Makeconf
- replace `-nographic` with explicit `-display none`, `-serial stdio`, and `-monitor none` options to prevent QEMU from binding multiple character devices to stdio

## Testing
- `bash -n scripts/setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d00fa2504c832fbe4097719ec8647f