### PR TITLE
Fix ham binary path lookup in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -23,7 +23,7 @@ if [ "$cmd" != "clean" ]; then
   "$SCRIPT_DIR/setup_l4re_env.sh"
 
   if ! command -v ham >/dev/null 2>&1; then
-    HAM_BIN="$(resolve_path "$SCRIPT_DIR/ham/ham")"
+    HAM_BIN="$(resolve_path "$SCRIPT_DIR/../ham/ham")"
     if [ -x "$HAM_BIN" ]; then
       PATH="$(dirname "$HAM_BIN"):$PATH"
       export PATH


### PR DESCRIPTION
## Summary
- fix setup.sh to resolve the ham helper from the repository root ham/ directory

## Testing
- bash -n scripts/setup.sh
- bash -n scripts/setup_l4re_env.sh

