### PR TITLE
Set default make target to all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-all: 
+.DEFAULT_GOAL := all
+
+all:
 	@if [ -d obj ]; then                                           \
 	  $(MAKE) build_all;                                           \
 	else                                                           \


### PR DESCRIPTION
## Summary
- explicitly set the Makefile default goal to the existing all target

## Testing
- make -n *(fails: initial setup not performed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0168bdedc832fbb0d62baef46fe8e