### PR TITLE
Fix debug guard in build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -182,7 +182,7 @@ prepare_rust_glibc_environment() {
 print_debug_environment() {
   if [ "$DEBUG_MODE" != true ]; then
     return
-  }
+  fi
 
   local rust_triple="(unavailable)"
   if rust_triple=$(determine_rust_target_triple 2>/dev/null); then


### PR DESCRIPTION
## Summary
- fix the guard clause in `print_debug_environment` to use `fi` instead of a closing brace so the build script parses correctly

## Testing
- bash -n scripts/build.sh
