### PR TITLE
Add dialog for configuring cross-compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ CROSS_COMPILE=aarch64-linux-gnu- scripts/build.sh  # Override any aarch64-elf- d
 ```
 
 Pass `--clean` (or select “Clean out directory before build” in the interactive
-menu) to remove previous build directories. 
+menu) to remove previous build directories.
 existing directories for incremental builds; `--no-clean` enforces this reuse in
 automation. Build artifacts are placed under `out/`.
+
+The interactive `dialog` menu also lets you review and edit the cross-compiler
+prefixes before building. Leave a field blank to fall back to the detected
+defaults or mirror the ARM64 prefix into the general `CROSS_COMPILE` setting.
 


### PR DESCRIPTION
## Summary
- add a dialog-based helper that allows interactive runs to review and override CROSS_COMPILE, CROSS_COMPILE_ARM, and CROSS_COMPILE_ARM64 while exporting the chosen values
- hook the helper into the interactive build flow after the clean prompt and exit cleanly when it is cancelled
- document in the README that the dialog menu now supports editing cross-compiler prefixes

## Testing
- `bash -n scripts/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d038ad17d8832faf351cd158063373