### PR TITLE
Add Rust toolchain prerequisite checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 L4ReRust brings Linux LSB and the Rust programming language to the L4 Runtime Environment (L4Re) microkernel.
 
+## Host prerequisites
+
+Install the following tools before invoking `scripts/build.sh`:
+
+- A Rust toolchain that provides both `cargo` and `rustc` (for example, via [`rustup`](https://rustup.rs/)).
+
+The sections below describe additional tooling required by specific parts of the build.
+
 ## Installing tool 'ham'
 
 The build scripts rely on the [`ham`](https://github.com/kernkonzept/ham)

--- a/scripts/common_build.sh
+++ b/scripts/common_build.sh
@@ -104,6 +104,8 @@ validate_tools() {
     git
     gmake
     curl
+    rustc
+    cargo
     "${CROSS_COMPILE_ARM}g++"
     "${CROSS_COMPILE_ARM64}g++"
     mke2fs
@@ -137,6 +139,10 @@ validate_tools() {
           echo "Required tool $tool not found (CROSS_COMPILE_ARM=${CROSS_COMPILE_ARM})" >&2
         elif [[ "$tool" == "${CROSS_COMPILE_ARM64}g++" ]]; then
           echo "Required tool $tool not found (CROSS_COMPILE_ARM64=${CROSS_COMPILE_ARM64})" >&2
+        elif [[ "$tool" == rustc ]]; then
+          echo "Required tool rustc not found. Install a Rust toolchain (e.g., via https://rustup.rs/)." >&2
+        elif [[ "$tool" == cargo ]]; then
+          echo "Required tool cargo not found. Install a Rust toolchain (e.g., via https://rustup.rs/)." >&2
         elif [[ "$tool" == ham ]]; then
           echo "Required tool ham not found. Install ham and ensure it is in your PATH" >&2
         else


### PR DESCRIPTION
## Summary
- ensure the build helper validates that both rustc and cargo are available with clear guidance when missing
- document the need for a Rust toolchain before invoking the standard build script

## Testing
- not run (not requested)
