### PR TITLE
Add glibc patch to use Linux syscalls for time APIs

### DIFF
--- a/scripts/patches/glibc/0001-Use-linux-syscalls-for-time-and-eventfd.patch
+++ b/scripts/patches/glibc/0001-Use-linux-syscalls-for-time-and-eventfd.patch
@@ -1,0 +1,1072 @@
+diff --git a/libc/eventfd.cc b/libc/eventfd.cc
+index ef00e635..8c88c7ee 100644
+--- a/libc/eventfd.cc
++++ b/libc/eventfd.cc
+@@ -5,253 +5,112 @@
+  * BSD license as described in the LICENSE file in the top-level directory.
+  */
+ 
++#include <errno.h>
++#include <fcntl.h>
++#include <stdint.h>
+ #include <sys/eventfd.h>
+-#include <fs/fs.hh>
+-#include <libc/libc.hh>
+-#include <osv/fcntl.h>
+-#include <osv/mutex.h>
+-#include <osv/condvar.h>
+-#include <osv/poll.h>
++#include <sys/syscall.h>
++#include <sys/types.h>
++#include <unistd.h>
+ 
+-class event_fd final : public special_file {
+-    public:
+-        event_fd(unsigned int initval, int is_semaphore,  int flags)
+-            :special_file(FREAD | FWRITE | flags, DTYPE_UNSPEC),
+-            _count(initval), _is_semaphore(is_semaphore)
+-        {}
++#ifndef OSV_LIBC_API
++#define OSV_LIBC_API __attribute__((__visibility__("default")))
++#endif
+ 
+-        int close() { return 0; }
+-
+-        virtual int read(struct uio *uio, int flags) override;
+-        virtual int write(struct uio *uio, int flags) override;
+-        virtual int poll(int events) override;
+-
+-    private:
+-        mutable mutex _mutex;
+-        uint64_t      _count;
+-        bool          _is_semaphore;
+-        condvar       _blocked_reader;
+-        condvar       _blocked_writer;
+-
+-    private:
+-        size_t copy_to_uio(uint64_t value, uio *uio);
+-        size_t copy_from_uio(uio *uio, uint64_t *value);
+-};
+-
+-size_t event_fd::copy_to_uio(uint64_t value, uio *uio)
+-{
+-    const char   *q = (const char *) &value;
+-    struct iovec *iov;
+-    size_t       n;
+-    char         *p;
+-
+-    size_t sz = sizeof(value);
+-    size_t bc = 0;
+-    for (int i = 0; i < uio->uio_iovcnt && sz != 0; i++) {
+-        iov = uio->uio_iov + i;
+-        n   = std::min(sz, iov->iov_len);
+-        p   = static_cast<char *> (iov->iov_base);
+-
+-        std::copy(q, q + n, p);
+-
+-        q  += n;
+-        sz -= n;
+-        bc += n;
+-    }
+-    return bc;
+-}
+-
+-size_t event_fd::copy_from_uio(uio *uio, uint64_t *value)
++extern "C" OSV_LIBC_API
++int eventfd(unsigned int initval, int flags)
+ {
+-    char         *q = (char *) value;
+-    struct iovec *iov;
+-    size_t       n;
+-    char         *p;
+-
+-    size_t sz = sizeof(*value);
+-    size_t bc = 0;
+-    for (int i = 0; i < uio->uio_iovcnt && sz != 0; i++) {
+-        iov = uio->uio_iov + i;
+-        n   = std::min(sz, iov->iov_len);
+-        p   = static_cast<char *> (iov->iov_base);
+-
+-        std::copy(p, p + n, q);
+-
+-        q  += n;
+-        sz -= n;
+-        bc += n;
++#if defined(SYS_eventfd2)
++    return (int)syscall(SYS_eventfd2, initval, flags);
++#elif defined(SYS_eventfd)
++    int fd = (int)syscall(SYS_eventfd, initval);
++    if (fd == -1) {
++        return -1;
++    }
++    if (flags & EFD_SEMAPHORE) {
++        errno = EINVAL;
++        close(fd);
++        return -1;
+     }
+-    return bc;
+-}
+-
+-int event_fd::read(uio *data, int flags)
+-{
+-    uint64_t v;
+-
+-    if (data->uio_resid < (ssize_t) sizeof(v)) {
+-        return EINVAL;
++    if (flags & EFD_CLOEXEC) {
++        int current = fcntl(fd, F_GETFD);
++        if (current == -1 || fcntl(fd, F_SETFD, current | FD_CLOEXEC) == -1) {
++            int saved = errno;
++            close(fd);
++            errno = saved;
++            return -1;
++        }
+     }
+-
+-    WITH_LOCK(_mutex) {
+-        for (;;) {
+-            if (_count > 0) {
+-                if (_is_semaphore) {
+-                    v = 1;
+-                } else {
+-                    v = _count;
+-                }
+-                _count -= v;
+-                break;
+-            } else {
+-                if (f_flags & O_NONBLOCK) {
+-                    return EAGAIN;
+-                }
+-                _blocked_reader.wait(_mutex);
+-            }
++    if (flags & EFD_NONBLOCK) {
++        int current = fcntl(fd, F_GETFL);
++        if (current == -1 || fcntl(fd, F_SETFL, current | O_NONBLOCK) == -1) {
++            int saved = errno;
++            close(fd);
++            errno = saved;
++            return -1;
+         }
+-
+-        data->uio_resid -= copy_to_uio(v, data);
+-        _blocked_writer.wake_all();
+     }
+-    poll_wake(this, POLLOUT);
+-
+-    return 0;
++    return fd;
++#else
++    errno = ENOSYS;
++    return -1;
++#endif
+ }
+ 
+-int event_fd::write(uio *data, int flags)
++static int read_full(int fd, void* buf, size_t len)
+ {
+-    uint64_t v;
+-
+-    if (data->uio_resid < (ssize_t) sizeof(v)) {
+-        return EINVAL;
+-    }
+-
+-    size_t bc = copy_from_uio(data, &v);
+-    if (v == ULLONG_MAX) {
+-        return EINVAL;
+-    }
+-
+-    WITH_LOCK(_mutex) {
+-        for (;;) {
+-            if (v < ULLONG_MAX - _count) {
+-                _count += v;
+-                break;
+-            } else {
+-                if (f_flags & O_NONBLOCK) {
+-                    return EAGAIN;
+-                }
+-                _blocked_writer.wait(_mutex);
++    char* out = static_cast<char*>(buf);
++    size_t total = 0;
++    while (total < len) {
++        ssize_t ret = read(fd, out + total, len - total);
++        if (ret == -1) {
++            if (errno == EINTR) {
++                continue;
+             }
++            return -1;
+         }
+-
+-        _blocked_reader.wake_all();
++        if (ret == 0) {
++            errno = EINVAL;
++            return -1;
++        }
++        total += static_cast<size_t>(ret);
+     }
+-    poll_wake(this, POLLIN);
+-
+-    /* update uio_resid only when count is updated. */
+-    data->uio_resid -= bc;
+-
+     return 0;
+ }
+ 
+-int event_fd::poll(int events)
++static int write_full(int fd, const void* buf, size_t len)
+ {
+-    int rc = 0;
+-
+-    WITH_LOCK(_mutex) {
+-        if ((_count > 0) && ((events & POLLIN) != 0)) {
+-            /* readable */
+-            rc |= POLLIN;
+-        }
+-
+-        if ((_count < ULLONG_MAX - 1) && ((events & POLLOUT) != 0)) {
+-            /* writable */
+-            rc |= POLLOUT;
++    const char* in = static_cast<const char*>(buf);
++    size_t total = 0;
++    while (total < len) {
++        ssize_t ret = write(fd, in + total, len - total);
++        if (ret == -1) {
++            if (errno == EINTR) {
++                continue;
++            }
++            return -1;
+         }
+-
+-        if (_count == ULLONG_MAX) {
+-            /* error on overflow */
+-            rc |= POLLERR;
++        if (ret == 0) {
++            errno = EINVAL;
++            return -1;
+         }
++        total += static_cast<size_t>(ret);
+     }
+-
+-    return rc;
+-}
+-
+-OSV_LIBC_API
+-int eventfd(unsigned int initval, int flags)
+-{
+-    if (flags & (~(EFD_CLOEXEC | EFD_NONBLOCK | EFD_SEMAPHORE))) {
+-        return libc_error(EINVAL);
+-    }
+-
+-    if (initval >= ULLONG_MAX) {
+-        return libc_error(EINVAL);
+-    }
+-
+-    int of = 0;
+-    if (flags & EFD_NONBLOCK) {
+-        of |= O_NONBLOCK;
+-    }
+-
+-    if (flags & EFD_CLOEXEC) {
+-        of |= O_CLOEXEC;
+-    }
+-
+-    bool is_semaphore = (flags & EFD_SEMAPHORE);
+-
+-    try {
+-        fileref f = make_file<event_fd>(initval, is_semaphore, of);
+-        fdesc fd(f);
+-        return fd.release();
+-    } catch (int error) {
+-        return libc_error(error);
+-    }
++    return 0;
+ }
+-weak_alias(eventfd, eventfd2);
+ 
+-OSV_LIBC_API
+-int eventfd_read(int fd, eventfd_t *value)
++extern "C" OSV_LIBC_API
++int eventfd_read(int fd, eventfd_t* value)
+ {
+-    fileref f(fileref_from_fd(fd));
+-    if (!f) {
+-        return libc_error(EBADF);
+-    }
+-
+-    auto ef = dynamic_cast<event_fd *> (f.get());
+-    if (!ef) {
+-        return libc_error(EBADF);
+-    }
+-
+-    struct iovec iov {value, sizeof(*value)};
+-    struct uio   uio {&iov, 1, 0, sizeof(*value), UIO_READ};
+-
+-    int rc = ef->read(&uio, 0);
+-    if (rc) {
+-        return libc_error(rc);
++    if (!value) {
++        errno = EINVAL;
++        return -1;
+     }
+-    return 0;
++    return read_full(fd, value, sizeof(*value));
+ }
+ 
+-OSV_LIBC_API
++extern "C" OSV_LIBC_API
+ int eventfd_write(int fd, eventfd_t value)
+ {
+-    fileref f(fileref_from_fd(fd));
+-    if (!f) {
+-        return libc_error(EBADF);
+-    }
+-
+-    auto ef = dynamic_cast<event_fd *> (f.get());
+-    if (!ef) {
+-        return libc_error(EBADF);
+-    }
+-
+-    struct iovec iov {&value, sizeof(value)};
+-    struct uio   uio {&iov, 1, 0, sizeof(value), UIO_WRITE};
+-
+-    int rc = ef->write(&uio, 0);
+-    if (rc) {
+-        return libc_error(rc);
+-    }
+-    return 0;
++    return write_full(fd, &value, sizeof(value));
+ }
+diff --git a/libc/time.cc b/libc/time.cc
+index 9f47a478..791e37f7 100644
+--- a/libc/time.cc
++++ b/libc/time.cc
+@@ -5,165 +5,189 @@
+  * BSD license as described in the LICENSE file in the top-level directory.
+  */
+ 
+-#include <api/utime.h>
++#include <errno.h>
++#include <stdint.h>
++#include <sys/syscall.h>
+ #include <sys/time.h>
++#include <sys/types.h>
+ #include <time.h>
+ #include <unistd.h>
+-#include <osv/stubbing.hh>
+-#include "libc.hh"
+-#include <osv/clock.hh>
+-#include <osv/sched.hh>
+-#include "pthread.hh"
+ 
+-u64 convert(const timespec& ts)
++#ifndef OSV_LIBC_API
++#define OSV_LIBC_API __attribute__((__visibility__("default")))
++#endif
++
++struct kernel_timespec {
++    long long tv_sec;
++    long long tv_nsec;
++};
++
++static inline void to_kernel_timespec(const struct timespec* ts,
++                                      struct kernel_timespec* kts)
+ {
+-    return ts.tv_sec * 1000000000 + ts.tv_nsec;
++    if (!ts || !kts) {
++        return;
++    }
++    kts->tv_sec = ts->tv_sec;
++    kts->tv_nsec = ts->tv_nsec;
+ }
+ 
+-extern "C" OSV_LIBC_API
+-int gettimeofday(struct timeval* tv, struct timezone* tz)
++static inline void from_kernel_timespec(struct timespec* ts,
++                                        const struct kernel_timespec* kts)
+ {
+-    if (!tv) {
+-        return 0;
++    if (!ts || !kts) {
++        return;
+     }
+-    using namespace std::chrono;
+-    auto d = osv::clock::wall::now().time_since_epoch();
+-    tv->tv_sec = duration_cast<seconds>(d).count();
+-    tv->tv_usec = duration_cast<microseconds>(d).count() % 1000000;
+-    return 0;
++    ts->tv_sec = (time_t)kts->tv_sec;
++    ts->tv_nsec = (long)kts->tv_nsec;
+ }
+ 
+-OSV_LIBC_API
+-int nanosleep(const struct timespec* req, struct timespec* rem)
++static int syscall_clock_gettime(clockid_t clk_id, struct timespec* ts)
+ {
+-    sched::thread::sleep(std::chrono::nanoseconds(convert(*req)));
+-    return 0;
++#if defined(SYS_clock_gettime64)
++    struct kernel_timespec kts;
++    long ret = syscall(SYS_clock_gettime64, clk_id, &kts);
++    if (ret == 0 && ts) {
++        from_kernel_timespec(ts, &kts);
++    }
++    return (int)ret;
++#else
++    return (int)syscall(SYS_clock_gettime, clk_id, ts);
++#endif
+ }
+ 
+-OSV_LIBC_API
+-int clock_nanosleep(clockid_t clock_id, int flags,
+-                    const struct timespec *request,
+-                    struct timespec *remain)
++static int syscall_clock_getres(clockid_t clk_id, struct timespec* ts)
+ {
+-    //We ignore the "remain" argument same way we do it above in nanosleep()
+-    //This argument is only relevant if the "sleeping" thread is interrupted
+-    //by signals. But OSv signal implementation is limited and would not allow
+-    //for such a scenario and both nanosleep() and clock_nanosleep() would
+-    //never return EINTR
+-    if (flags || clock_id != CLOCK_REALTIME) {
+-        return ENOTSUP;
++#if defined(SYS_clock_getres_time64)
++    struct kernel_timespec kts;
++    long ret = syscall(SYS_clock_getres_time64, clk_id, &kts);
++    if (ret == 0 && ts) {
++        from_kernel_timespec(ts, &kts);
+     }
+-    sched::thread::sleep(std::chrono::nanoseconds(convert(*request)));
+-    return 0;
++    return (int)ret;
++#else
++    return (int)syscall(SYS_clock_getres, clk_id, ts);
++#endif
+ }
+ 
+-OSV_LIBC_API
+-int usleep(useconds_t usec)
++static int syscall_nanosleep(const struct timespec* req, struct timespec* rem)
+ {
+-    sched::thread::sleep(std::chrono::microseconds(usec));
+-    return 0;
++#if defined(SYS_nanosleep_time64)
++    struct kernel_timespec req64;
++    struct kernel_timespec rem64;
++    struct kernel_timespec* rem_arg = NULL;
++    to_kernel_timespec(req, &req64);
++    if (rem) {
++        rem_arg = &rem64;
++    }
++    long ret = syscall(SYS_nanosleep_time64, &req64, rem_arg);
++    if (rem && (ret == 0 || (ret == -1 && errno == EINTR))) {
++        from_kernel_timespec(rem, &rem64);
++    }
++    return (int)ret;
++#else
++    return (int)syscall(SYS_nanosleep, req, rem);
++#endif
+ }
+ 
+-// Convenient inline function for converting std::chrono::duration,
+-// of a clock with any period, into the classic Posix "struct timespec":
+-template <class Rep, class Period>
+-static inline void fill_ts(std::chrono::duration<Rep, Period> d, timespec *ts)
++static int syscall_clock_nanosleep(clockid_t clock_id, int flags,
++                                   const struct timespec* request,
++                                   struct timespec* remain)
+ {
+-    using namespace std::chrono;
+-    ts->tv_sec = duration_cast<seconds>(d).count();
+-    ts->tv_nsec = duration_cast<nanoseconds>(d).count() % 1000000000;
++#if defined(SYS_clock_nanosleep_time64)
++    struct kernel_timespec req64;
++    struct kernel_timespec rem64;
++    struct kernel_timespec* rem_arg = NULL;
++    to_kernel_timespec(request, &req64);
++    if (remain) {
++        rem_arg = &rem64;
++    }
++    long ret = syscall(SYS_clock_nanosleep_time64, clock_id, flags, &req64,
++                       rem_arg);
++    if (remain && (ret == 0 || (ret == -1 && errno == EINTR))) {
++        from_kernel_timespec(remain, &rem64);
++    }
++    return (int)ret;
++#else
++    return (int)syscall(SYS_clock_nanosleep, clock_id, flags, request, remain);
++#endif
+ }
+ 
+-OSV_LIBC_API
+-int clock_gettime(clockid_t clk_id, struct timespec* ts)
++extern "C" OSV_LIBC_API
++int gettimeofday(struct timeval* tv, struct timezone* tz)
+ {
+-    switch (clk_id) {
+-    case CLOCK_BOOTTIME:
+-    case CLOCK_MONOTONIC:
+-    case CLOCK_MONOTONIC_COARSE:
+-    case CLOCK_MONOTONIC_RAW:
+-        fill_ts(osv::clock::uptime::now().time_since_epoch(), ts);
+-        break;
+-    case CLOCK_REALTIME:
+-    case CLOCK_REALTIME_COARSE:
+-        fill_ts(osv::clock::wall::now().time_since_epoch(), ts);
+-        break;
+-    case CLOCK_PROCESS_CPUTIME_ID:
+-        fill_ts(sched::process_cputime(), ts);
+-        break;
+-    case CLOCK_THREAD_CPUTIME_ID:
+-        fill_ts(sched::thread::current()->thread_clock(), ts);
+-        break;
+-
+-    default:
+-        //At this point we should only let the negative numbers
+-        //which represent clock_id for specific thread
+-        if (clk_id >= 0) {
+-            return libc_error(EINVAL);
+-        } else {
+-            //Reverse the formula used in pthread_getcpuclockid()
+-            //and calculate thread id given clk_id
+-            pid_t tid = (-clk_id - 2) / 8;
+-            auto thread = sched::thread::find_by_id(tid);
+-            if (thread) {
+-                fill_ts(thread->thread_clock(), ts);
+-            } else {
+-                return libc_error(EINVAL);
+-            }
+-        }
+-    }
++    return (int)syscall(SYS_gettimeofday, tv, tz);
++}
+ 
+-    return 0;
++extern "C" OSV_LIBC_API
++int nanosleep(const struct timespec* req, struct timespec* rem)
++{
++    return syscall_nanosleep(req, rem);
++}
++
++extern "C" OSV_LIBC_API
++int clock_nanosleep(clockid_t clock_id, int flags,
++                    const struct timespec* request,
++                    struct timespec* remain)
++{
++    return syscall_clock_nanosleep(clock_id, flags, request, remain);
++}
++
++extern "C" OSV_LIBC_API
++int usleep(useconds_t usec)
++{
++    struct timespec ts;
++    ts.tv_sec = usec / 1000000;
++    ts.tv_nsec = (usec % 1000000) * 1000;
++    return syscall_nanosleep(&ts, NULL);
++}
++
++extern "C" OSV_LIBC_API
++int clock_gettime(clockid_t clk_id, struct timespec* ts)
++{
++    return syscall_clock_gettime(clk_id, ts);
+ }
+ 
+ extern "C" OSV_LIBC_API
+-int __clock_gettime(clockid_t clk_id, struct timespec* ts) __attribute__((alias("clock_gettime")));
++int __clock_gettime(clockid_t clk_id, struct timespec* ts)
++    __attribute__((alias("clock_gettime")));
+ 
+-OSV_LIBC_API
++extern "C" OSV_LIBC_API
+ int clock_getres(clockid_t clk_id, struct timespec* ts)
+ {
+-    switch (clk_id) {
+-    case CLOCK_BOOTTIME:
+-    case CLOCK_REALTIME:
+-    case CLOCK_REALTIME_COARSE:
+-    case CLOCK_PROCESS_CPUTIME_ID:
+-    case CLOCK_THREAD_CPUTIME_ID:
+-    case CLOCK_MONOTONIC:
+-    case CLOCK_MONOTONIC_COARSE:
+-    case CLOCK_MONOTONIC_RAW:
+-        break;
+-    default:
+-        //At this point we should only let the negative numbers
+-        //which represent clock_id for specific thread
+-        if (clk_id >= 0) {
+-            return libc_error(EINVAL);
+-        } else {
+-            //Reverse the formula used in pthread_getcpuclockid()
+-            //and calculate thread id given clk_id
+-            pid_t tid = (-clk_id - 2) / 8;
+-            if( !sched::thread::find_by_id(tid)) {
+-                return libc_error(EINVAL);
+-            }
+-        }
+-    }
++    return syscall_clock_getres(clk_id, ts);
++}
+ 
+-    if (ts) {
+-        ts->tv_sec = 0;
+-        ts->tv_nsec = 1;
+-    }
+-    return 0;
++#define CPUCLOCK_PERTHREAD_MASK 4
++#define CPUCLOCK_CLOCK_MASK 3
++#define CPUCLOCK_SCHED 2
++
++static inline clockid_t make_process_cpuclock(pid_t pid, int clock)
++{
++    return ((~(clockid_t)pid) << 3) | (clock & CPUCLOCK_CLOCK_MASK);
+ }
+ 
+-OSV_LIBC_API
++extern "C" OSV_LIBC_API
+ int clock_getcpuclockid(pid_t pid, clockid_t* clock_id)
+ {
+-    return CLOCK_PROCESS_CPUTIME_ID;
++    if (!clock_id) {
++        errno = EINVAL;
++        return -1;
++    }
++    *clock_id = make_process_cpuclock(pid, CPUCLOCK_SCHED);
++    struct timespec ts;
++    if (syscall_clock_getres(*clock_id, &ts) == -1) {
++        return -1;
++    }
++    return 0;
+ }
+ 
+-OSV_LIBC_API
++extern "C" OSV_LIBC_API
+ clock_t clock(void)
+ {
+     struct timespec ts;
+-    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+-    return ts.tv_sec * 1000000000L + ts.tv_nsec;
++    if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) != 0) {
++        return (clock_t)-1;
++    }
++    return (clock_t)(ts.tv_sec * 1000000000LL + ts.tv_nsec);
+ }
+diff --git a/libc/timerfd.cc b/libc/timerfd.cc
+index 95517889..dcec0e99 100644
+--- a/libc/timerfd.cc
++++ b/libc/timerfd.cc
+@@ -5,333 +5,117 @@
+  * BSD license as described in the LICENSE file in the top-level directory.
+  */
+ 
+-#include <fs/fs.hh>
+-#include <osv/fcntl.h>
+-#include <libc/libc.hh>
+-#include <osv/stubbing.hh>
+-#include <osv/sched.hh>
+-#include <osv/poll.h>
+-#include <osv/mutex.h>
+-#include <osv/condvar.h>
+-#include <osv/kernel_config_lazy_stack.h>
+-#include <osv/kernel_config_lazy_stack_invariant.h>
+-
++#include <errno.h>
++#include <stddef.h>
++#include <stdint.h>
++#include <sys/syscall.h>
+ #include <sys/timerfd.h>
++#include <time.h>
+ 
+-#include <atomic>
+-
+-class timerfd final : public special_file {
+-public:
+-    explicit timerfd(int clockid, int flags);
+-    virtual int read(uio* data, int flags) override;
+-    virtual int poll(int events) override;
+-    virtual int close() override;
+-    void set(s64 expiration, s64 interval);
+-    void get(s64 &expiration, s64 &interval) const;
+-
+-private:
+-    mutable mutex _mutex;
+-
+-    // _expiration is the time when the timerfd becomes readable and read()
+-    // will return 1. After this time, the value to be returned by read()
+-    // will increase by 1 on every _interval.
+-    s64 _expiration = 0;
+-    s64 _interval = 0;
+-
+-    // Each timerfd keeps a timer for wakeup of sleeping read() or poll()
+-    // in a dedicated thread. We could have used a timer_base::client instead
+-    // of a real thread, but things get really complicated when trying to
+-    // support set() which cancels on one CPU the timer set on another CPU.
+-    std::unique_ptr<sched::thread> _wakeup_thread;
+-    s64 _wakeup_due = 0;
+-    condvar _wakeup_change_cond;
+-    bool _wakeup_thread_exit = false;
+-    condvar _blocked_reader;
+-    void wakeup_thread_func();
++#ifndef OSV_LIBC_API
++#define OSV_LIBC_API __attribute__((__visibility__("default")))
++#endif
+ 
+-    // Which clock to use to interpret s64 times.
+-    int _clockid;
+-    void set_timer(sched::timer &tmr, s64 time);
+-public:
+-    s64 time_now() const;
++struct kernel_timespec {
++    long long tv_sec;
++    long long tv_nsec;
+ };
+ 
+-timerfd::timerfd(int clockid, int oflags)
+-    : special_file(FREAD | oflags, DTYPE_UNSPEC),
+-      _wakeup_thread(sched::thread::make(
+-            [&] { wakeup_thread_func(); }, sched::thread::attr().stack(4096).name("timerfd"))),
+-      _clockid(clockid)
+-{
+-    _wakeup_thread->start();
+-}
+-
+-int timerfd::close() {
+-    WITH_LOCK(_mutex) {
+-        _wakeup_thread_exit = true;
+-        _wakeup_change_cond.wake_one();
+-    }
+-    _wakeup_thread->join();
+-    return 0;
+-}
+-
+-void timerfd::set_timer(sched::timer &tmr, s64 t)
+-{
+-    using namespace osv::clock;
+-    switch(_clockid) {
+-    case CLOCK_REALTIME:
+-        tmr.set(wall::time_point(std::chrono::nanoseconds(t)));
+-        break;
+-    case CLOCK_MONOTONIC:
+-        tmr.set(uptime::time_point(std::chrono::nanoseconds(t)));
+-        break;
+-    default:
+-        assert(false);
+-    }
+-}
+-
+-s64 timerfd::time_now() const
+-{
+-    using namespace std::chrono;
+-    switch(_clockid) {
+-    case CLOCK_REALTIME:
+-        return duration_cast<nanoseconds>(
+-                osv::clock::wall::now().time_since_epoch()).count();
+-    case CLOCK_MONOTONIC:
+-        return duration_cast<nanoseconds>(
+-                osv::clock::uptime::now().time_since_epoch()).count();
+-    default:
+-        assert(false);
+-    }
+-}
+-
+-void timerfd::wakeup_thread_func()
+-{
+-    sched::timer tmr(*sched::thread::current());
+-    WITH_LOCK(_mutex) {
+-        while (!_wakeup_thread_exit) {
+-            if (_wakeup_due != 0) {
+-                set_timer(tmr, _wakeup_due);
+-                _wakeup_change_cond.wait(_mutex, &tmr);
+-                if (tmr.expired()) {
+-                    _wakeup_due = 0;
+-                    // Wake blocked read() or poll() on this fd
+-                    _blocked_reader.wake_one();
+-                    poll_wake(this, POLLIN);
+-                } else {
+-#if CONF_lazy_stack_invariant
+-                    assert(!sched::thread::current()->is_app());
+-#endif
+-                    tmr.cancel();
+-                }
+-            } else {
+-                _wakeup_change_cond.wait(_mutex);
+-            }
+-        }
+-    }
+-}
+-
+-void timerfd::set(s64 expiration, s64 interval)
+-{
+-    WITH_LOCK(_mutex) {
+-        _expiration = expiration;
+-        _interval = interval;
+-        _wakeup_due = expiration;
+-        _wakeup_change_cond.wake_one();
+-        _blocked_reader.wake_one();
+-    }
+-}
++struct kernel_itimerspec {
++    kernel_timespec it_interval;
++    kernel_timespec it_value;
++};
+ 
+-void timerfd::get(s64 &expiration, s64 &interval) const
++static inline void to_kernel_timespec(const struct timespec* ts,
++                                      kernel_timespec* kts)
+ {
+-    WITH_LOCK(_mutex) {
+-        if (_expiration && !_wakeup_due) {
+-            // already expired, calculate the time of the next expiration
+-            if (!_interval) {
+-                expiration = 0;
+-            } else {
+-                auto now = time_now();
+-                u64 count = (now - _expiration) / _interval;
+-                expiration = _expiration + (count+1) * _interval;
+-            }
+-        } else {
+-            expiration = _expiration;
+-        }
+-        interval = _interval;
++    if (!ts || !kts) {
++        return;
+     }
++    kts->tv_sec = ts->tv_sec;
++    kts->tv_nsec = ts->tv_nsec;
+ }
+ 
+-// Copy from the byte array into the given iovec array, stopping when either
+-// the array or iovec runs out. Decrements uio->uio_resid.
+-static void copy_to_uio(const char *q, size_t qlen, uio *uio)
++static inline void from_kernel_timespec(struct timespec* ts,
++                                        const kernel_timespec* kts)
+ {
+-    for (int i = 0; i < uio->uio_iovcnt && qlen; i++) {
+-        auto &iov = uio->uio_iov[i];
+-        auto n = std::min(qlen, iov.iov_len);
+-        char* p = static_cast<char*>(iov.iov_base);
+-        std::copy(q, q + n, p);
+-        q += n;
+-        qlen -= n;
+-        uio->uio_resid -= n;
++    if (!ts || !kts) {
++        return;
+     }
++    ts->tv_sec = (time_t)kts->tv_sec;
++    ts->tv_nsec = (long)kts->tv_nsec;
+ }
+ 
+-int timerfd::read(uio *data, int flags)
++static inline void to_kernel_itimerspec(const struct itimerspec* src,
++                                        kernel_itimerspec* dst)
+ {
+-    u64 ret;
+-
+-    if (data->uio_resid < (ssize_t) sizeof(ret)) {
+-        return EINVAL;
+-    }
+-
+-    WITH_LOCK(_mutex) {
+-again:
+-        while (!_expiration || _wakeup_due) {
+-            if (f_flags & O_NONBLOCK) {
+-                return EAGAIN;
+-            }
+-            _blocked_reader.wait(_mutex);
+-        }
+-        // Read the timerfd's current count of expirations since the last
+-        // read() or set(). If an interval is set, also set a timer until
+-        // the next expiration.
+-        if (!_interval) {
+-            ret = 1;
+-            _expiration = 0;
+-        } else {
+-            auto now = time_now();
+-            if (_clockid == CLOCK_MONOTONIC || now >= _expiration) {
+-                // set next wakeup for the next multiple of interval from
+-                // _expiration which is after "now".
+-                assert (now >= _expiration);
+-                u64 count = (now - _expiration) / _interval;
+-                _expiration = _expiration + (count+1) * _interval;
+-                _wakeup_due = _expiration;
+-                _wakeup_change_cond.wake_one();
+-                ret = 1 + count;
+-            } else {
+-                // Clock is REALTIME and now < _expiration (clock may have jumped backwards)
+-                _wakeup_due = _expiration;
+-                _wakeup_change_cond.wake_one();
+-                goto again;
+-            }
+-        }
+-        copy_to_uio((const char *)&ret, sizeof(ret), data);
+-        return 0;
++    if (!src || !dst) {
++        return;
+     }
++    to_kernel_timespec(&src->it_interval, &dst->it_interval);
++    to_kernel_timespec(&src->it_value, &dst->it_value);
+ }
+ 
+-int timerfd::poll(int events)
++static inline void from_kernel_itimerspec(struct itimerspec* dst,
++                                          const kernel_itimerspec* src)
+ {
+-    WITH_LOCK(_mutex) {
+-        if (!_expiration || _wakeup_due) {
+-            return 0;
+-        } else {
+-            return POLLIN;
+-        }
+-    }
+-}
+-
+-// After this long introduction, without further ado, let's implement Linux's
+-// three <sys/timerfd.h> functions:
+-
+-OSV_LIBC_API
+-int timerfd_create(int clockid, int flags) {
+-    switch (clockid) {
+-    case CLOCK_REALTIME:
+-    case CLOCK_MONOTONIC:
+-        // fine.
+-        break;
+-    default:
+-        return libc_error(EINVAL);
+-    }
+-    if (flags & ~(TFD_NONBLOCK | TFD_CLOEXEC)) {
+-        return libc_error(EINVAL);
+-    }
+-    try {
+-        int oflags = (flags & TFD_NONBLOCK) ? O_NONBLOCK : 0;
+-        fileref f = make_file<timerfd>(clockid, oflags);
+-        fdesc fd(f);
+-        return fd.release();
+-    } catch (int error) {
+-        return libc_error(error);
++    if (!dst || !src) {
++        return;
+     }
++    from_kernel_timespec(&dst->it_interval, &src->it_interval);
++    from_kernel_timespec(&dst->it_value, &src->it_value);
+ }
+ 
+-static constexpr s64 second = 1000000000;
+-
+-static bool check_nsec_validity(long nsec)
++extern "C" OSV_LIBC_API
++int timerfd_create(int clockid, int flags)
+ {
+-    return (nsec >= 0 && nsec < second);
++#if defined(SYS_timerfd_create)
++    return (int)syscall(SYS_timerfd_create, clockid, flags);
++#else
++    errno = ENOSYS;
++    return -1;
++#endif
+ }
+ 
+-OSV_LIBC_API
+-int timerfd_settime(int fd, int flags, const itimerspec *newval,
+-        itimerspec *oldval)
++extern "C" OSV_LIBC_API
++int timerfd_settime(int fd, int flags, const struct itimerspec* new_value,
++                    struct itimerspec* old_value)
+ {
+-    fileref f(fileref_from_fd(fd));
+-    if (!f) {
+-        errno = EBADF;
+-        return -1;
+-    }
+-    auto tf = dynamic_cast<timerfd*>(f.get());
+-    if (!tf) {
+-        errno = EINVAL;
+-        return -1;
+-    }
+-    if (!check_nsec_validity(newval->it_value.tv_nsec) ||
+-        !check_nsec_validity(newval->it_interval.tv_nsec)) {
+-        errno = EINVAL;
+-        return -1;
+-    }
+-
+-    s64 expiration, interval;
+-    auto now = tf->time_now();
+-    if (oldval) {
+-        tf->get(expiration, interval);
+-        if (expiration) {
+-            // oldval is always returned in relative time
+-            expiration -= now;
+-        }
+-        oldval->it_value.tv_sec = expiration / second;
+-        oldval->it_value.tv_nsec = expiration % second;
+-        oldval->it_interval.tv_sec = interval / second;
+-        oldval->it_interval.tv_nsec = interval % second;
+-    }
+-
+-    expiration = newval->it_value.tv_sec * second + newval->it_value.tv_nsec;
+-    interval = newval->it_interval.tv_sec * second + newval->it_interval.tv_nsec;
+-    if (flags != TFD_TIMER_ABSTIME && expiration) {
+-        expiration += now;
+-    }
+-
+-    tf->set(expiration, interval);
+-    return 0;
++#if defined(SYS_timerfd_settime64)
++    kernel_itimerspec new_value64;
++    kernel_itimerspec old_value64;
++    kernel_itimerspec* old_arg = NULL;
++    to_kernel_itimerspec(new_value, &new_value64);
++    if (old_value) {
++        old_arg = &old_value64;
++    }
++    long ret = syscall(SYS_timerfd_settime64, fd, flags, &new_value64, old_arg);
++    if (old_value && ret == 0) {
++        from_kernel_itimerspec(old_value, &old_value64);
++    }
++    return (int)ret;
++#elif defined(SYS_timerfd_settime)
++    return (int)syscall(SYS_timerfd_settime, fd, flags, new_value, old_value);
++#else
++    errno = ENOSYS;
++    return -1;
++#endif
+ }
+ 
+-OSV_LIBC_API
+-int timerfd_gettime(int fd, itimerspec *val)
++extern "C" OSV_LIBC_API
++int timerfd_gettime(int fd, struct itimerspec* value)
+ {
+-    fileref f(fileref_from_fd(fd));
+-    if (!f) {
+-        errno = EBADF;
+-        return -1;
+-    }
+-    auto tf = dynamic_cast<timerfd*>(f.get());
+-    if (!tf) {
+-        errno = EINVAL;
+-        return -1;
+-    }
+-
+-    s64 expiration, interval;
+-    auto now = tf->time_now();
+-    tf->get(expiration, interval);
+-    if (expiration) {
+-        // timerfd_gettime() wants relative time
+-        expiration -= now;
+-    }
+-    val->it_value.tv_sec = expiration / second;
+-    val->it_value.tv_nsec = expiration % second;
+-    val->it_interval.tv_sec = interval / second;
+-    val->it_interval.tv_nsec = interval % second;
+-    return 0;
++#if defined(SYS_timerfd_gettime64)
++    kernel_itimerspec value64;
++    long ret = syscall(SYS_timerfd_gettime64, fd, &value64);
++    if (ret == 0) {
++        from_kernel_itimerspec(value, &value64);
++    }
++    return (int)ret;
++#elif defined(SYS_timerfd_gettime)
++    return (int)syscall(SYS_timerfd_gettime, fd, value);
++#else
++    errno = ENOSYS;
++    return -1;
++#endif
+ }


### PR DESCRIPTION
## Summary
- add a glibc patch that rewrites eventfd, timerfd, and clock/time functions to invoke Linux syscalls directly
- drop dependencies on OSv-specific headers in those libc sources so they compile with standard Linux headers

## Testing
- ./scripts/build_glibc.sh arm64 aarch64-linux-gnu- fe48bcd9065ac625a54aef7b6c46fe70db8fcf7f /tmp/glibc-test https://github.com/cloudius-systems/osv.git fe48bcd9065ac625a54aef7b6c46fe70db8fcf7f musl_1.1.24 ea9525c8bcf6170df59364c4bcd616de1acf8703 *(fails: missing python3-distro dependency after patches applied)*
