### PR TITLE
Stage rootfs image during build and attach it in runqemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ The interactive `dialog` menu also lets you review and edit the cross-compiler
 prefixes before building. Leave a field blank to fall back to the detected
 defaults or mirror the ARM64 prefix into the general `CROSS_COMPILE` setting.
 
+## Running the QEMU Environment
+
+After a successful build, invoke `scripts/runqemu.sh` to boot the latest
+staged image inside QEMU. The helper automatically copies
+`out/images/lsb_root.img` into `distribution/images/` during the build and
+attaches the resulting root filesystem to QEMU as a virtio-blk device.
+
+Pass `--rootfs /path/to/other.img` to try an alternate filesystem or
+`--no-rootfs` to skip attaching any block device when debugging bare kernels.
+Additional arguments after `--` are forwarded verbatim to the underlying QEMU
+invocation.
+
 ## Documentation
 
 - [Integrating musl libc with L4Re](docs/musl_integration_whitepaper.md)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1686,11 +1686,24 @@ PY
     local source_root="obj/l4"
     local distribution_dir="distribution"
     local distribution_images_dir="$distribution_dir/images"
+    local staged_rootfs_source="${ARTIFACTS_DIR:-out}/images/lsb_root.img"
+    local staged_rootfs_dest="$distribution_images_dir/lsb_root.img"
 
     mkdir -p "$distribution_images_dir"
 
     if [ ! -d "$source_root" ]; then
       return
+    fi
+
+    if [ -f "$staged_rootfs_source" ]; then
+      if [ "$staged_rootfs_source" -ef "$staged_rootfs_dest" ]; then
+        :
+      else
+        echo "Staging root filesystem $(basename "$staged_rootfs_source") into $distribution_images_dir"
+        cp -f "$staged_rootfs_source" "$staged_rootfs_dest"
+      fi
+    else
+      echo "Warning: root filesystem image not found at $staged_rootfs_source; skipping staging" >&2
     fi
 
     local -a images=()

--- a/scripts/runqemu.sh
+++ b/scripts/runqemu.sh
@@ -4,6 +4,75 @@ set -euo pipefail
 SCRIPT_DIR="$(dirname "$0")"
 REPO_ROOT="$SCRIPT_DIR/.."
 DEFAULT_IMAGE_DIR="$REPO_ROOT/distribution"
+DEFAULT_ROOTFS_IMAGE="$DEFAULT_IMAGE_DIR/images/lsb_root.img"
+
+usage() {
+  cat <<'USAGE'
+Usage: runqemu.sh [OPTIONS] [IMAGE]
+
+Launch the most recent bootable image (or the IMAGE argument) in QEMU.
+
+Options:
+  -r, --rootfs PATH    Use PATH as the virtio-blk root filesystem image.
+                       Defaults to distribution/images/lsb_root.img.
+      --no-rootfs      Do not attach a root filesystem image.
+  -h, --help           Show this help and exit.
+  --                   Forward the remaining arguments directly to QEMU.
+USAGE
+}
+
+ROOTFS_PATH=""
+ATTACH_ROOTFS=true
+USER_QEMU_ARGS=()
+IMAGE_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -r|--rootfs)
+      if [[ $# -lt 2 ]]; then
+        echo "--rootfs requires a path argument" >&2
+        usage >&2
+        exit 1
+      fi
+      ROOTFS_PATH="$2"
+      ATTACH_ROOTFS=true
+      shift 2
+      ;;
+    --rootfs=*)
+      ROOTFS_PATH="${1#*=}"
+      ATTACH_ROOTFS=true
+      shift
+      ;;
+    --no-rootfs)
+      ROOTFS_PATH=""
+      ATTACH_ROOTFS=false
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      USER_QEMU_ARGS=("$@")
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "${IMAGE_PATH:-}" ]]; then
+        echo "Multiple image paths specified: '$IMAGE_PATH' and '$1'" >&2
+        usage >&2
+        exit 1
+      fi
+      IMAGE_PATH="$1"
+      shift
+      ;;
+  esac
+done
 
 select_latest_image() {
   local latest_image=""
@@ -43,8 +112,6 @@ if latest_bootstrap=$(select_latest_image "${bootstrap_images[@]}"); then
   DEFAULT_IMAGE_CANDIDATE="$latest_bootstrap"
 fi
 
-IMAGE_PATH="${1:-}"
-
 if [[ -z "$IMAGE_PATH" ]]; then
   if [[ -n "$DEFAULT_IMAGE_CANDIDATE" && -f "$DEFAULT_IMAGE_CANDIDATE" ]]; then
     IMAGE_PATH="$DEFAULT_IMAGE_CANDIDATE"
@@ -75,6 +142,35 @@ if [[ ! -f "$IMAGE_PATH" ]]; then
   exit 1
 fi
 
+if [[ "$ATTACH_ROOTFS" == true ]]; then
+  if [[ -z "$ROOTFS_PATH" ]]; then
+    ROOTFS_PATH="$DEFAULT_ROOTFS_IMAGE"
+  fi
+
+  if [[ ! -f "$ROOTFS_PATH" ]]; then
+    echo "Root filesystem image '$ROOTFS_PATH' does not exist." >&2
+    echo "Run scripts/build.sh --components lsb_root or pass --no-rootfs to skip attaching it." >&2
+    exit 1
+  fi
+fi
+
 echo "Launching image: $IMAGE_PATH"
 
-"$REPO_ROOT/src/l4/tool/bin/l4image" -i "$IMAGE_PATH" launch
+qemu_args=()
+if [[ "$ATTACH_ROOTFS" == true ]]; then
+  echo "Attaching root filesystem: $ROOTFS_PATH"
+  qemu_args+=("-drive" "if=none,file=$ROOTFS_PATH,format=raw,id=lsb_root")
+  qemu_args+=("-device" "virtio-blk-device,drive=lsb_root")
+fi
+
+if (( ${#USER_QEMU_ARGS[@]} )); then
+  qemu_args+=("${USER_QEMU_ARGS[@]}")
+fi
+
+cmd=("$REPO_ROOT/src/l4/tool/bin/l4image" -i "$IMAGE_PATH" launch)
+
+if (( ${#qemu_args[@]} )); then
+  cmd+=(-- "${qemu_args[@]}")
+fi
+
+"${cmd[@]}"


### PR DESCRIPTION
## Summary
- stage the generated lsb_root.img into distribution/images alongside bootable ELFs/U-Boot images
- extend scripts/runqemu.sh to attach the staged root filesystem by default, allow overrides, and forward extra QEMU arguments
- document the updated QEMU workflow and rootfs handling in the README

## Testing
- scripts/runqemu.sh --