### PR TITLE
Improve repository clean-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/target/
+**/Cargo.lock
+!/Cargo.lock
 config/pkg_staging/


### PR DESCRIPTION
## Summary
- ensure `scripts/setup.sh` always operates from the repository root and removes Cargo-generated artifacts during `clean`
- ignore nested Cargo.lock files so build products no longer appear as untracked files

## Testing
- scripts/setup.sh clean