### PR TITLE
Optimize scheduler ready queues

### DIFF
--- a/crates/l4/scheduler/autosar.rs
+++ b/crates/l4/scheduler/autosar.rs
@@ -58,8 +58,7 @@ impl AutosarScheduler {
         let prio = self.tasks[&id].current_priority;
         let pos = self
             .ready
-            .binary_search_by_key(&prio, |tid| self.tasks[tid].current_priority)
-            .unwrap_or_else(|e| e);
+            .partition_point(|tid| self.tasks[tid].current_priority > prio);
         self.ready.insert(pos, id);
     }
 
@@ -87,8 +86,7 @@ impl AutosarScheduler {
     }
 
     fn run_next(&mut self) {
-        if let Some(next_id) = self.ready.first().cloned() {
-            self.ready.remove(0);
+        if let Some(next_id) = self.ready.pop() {
             self.current = Some(next_id);
             #[cfg(not(test))]
             unsafe {
@@ -118,8 +116,7 @@ impl AutosarScheduler {
             let prio = self.tasks[&task].current_priority;
             let pos = m
                 .waiters
-                .binary_search_by_key(&prio, |tid| self.tasks[tid].current_priority)
-                .unwrap_or_else(|e| e);
+                .partition_point(|tid| self.tasks[tid].current_priority > prio);
             m.waiters.insert(pos, task);
             let owner = m.owner.unwrap();
             {
@@ -140,8 +137,7 @@ impl AutosarScheduler {
     pub fn unlock_mutex(&mut self, task: usize, mutex: usize) {
         if let Some(m) = self.mutexes.get_mut(&mutex) {
             if m.owner == Some(task) {
-                if let Some(next) = m.waiters.first().cloned() {
-                    m.waiters.remove(0);
+                if let Some(next) = m.waiters.pop() {
                     m.owner = Some(next);
                     self.tasks
                         .get_mut(&next)
@@ -161,7 +157,7 @@ impl AutosarScheduler {
                     self.tasks[&task].base_priority,
                     |p, &m_id| {
                         if let Some(mstate) = self.mutexes.get(&m_id) {
-                            if let Some(waiter) = mstate.waiters.first() {
+                            if let Some(waiter) = mstate.waiters.last() {
                                 min(p, self.tasks[waiter].current_priority)
                             } else {
                                 p
@@ -179,7 +175,7 @@ impl AutosarScheduler {
                     self.ready.retain(|&tid| tid != task);
                     self.insert_ready_sorted(task);
                 } else if self.current == Some(task) {
-                    if let Some(&next_id) = self.ready.first() {
+                    if let Some(&next_id) = self.ready.last() {
                         let next_prio = self.tasks[&next_id].current_priority;
                         if next_prio < self.tasks[&task].current_priority {
                             self.preempt();

--- a/crates/l4/scheduler/linux_like.rs
+++ b/crates/l4/scheduler/linux_like.rs
@@ -55,8 +55,7 @@ impl LinuxLikeScheduler {
         let vr = self.tasks[&id].vruntime;
         let pos = self
             .ready
-            .binary_search_by(|tid| self.tasks[tid].vruntime.cmp(&vr))
-            .unwrap_or_else(|e| e);
+            .partition_point(|tid| self.tasks[tid].vruntime > vr);
         self.ready.insert(pos, id);
     }
 
@@ -82,8 +81,7 @@ impl LinuxLikeScheduler {
     }
 
     fn run_next(&mut self) {
-        if let Some(next) = self.ready.first().cloned() {
-            self.ready.remove(0);
+        if let Some(next) = self.ready.pop() {
             let task = self.tasks.get_mut(&next).unwrap();
             task.remaining = task.slice;
             self.current = Some(next);


### PR DESCRIPTION
## Summary
- maintain ready and waiter queues in descending priority order so we can pop from the back in O(1)
- update AUTOSAR and linux-like schedulers to peek at the new back element when deciding the next task to run

## Testing
- cargo test -p l4 *(fails: missing `l4/sys/ipc.h` header during build)*
