### PR TITLE
Populate Rust target menu from rustc target list

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ automation. Build artifacts are placed under `out/`.
 The interactive `dialog` menu also lets you review and edit the cross-compiler
 prefixes before building. The form now includes the Rust target triple (applied
 to `CARGO_BUILD_TARGET`/`RUST_TARGET_TRIPLE`) so the Rust toolchain follows the
-selected cross-compilers. A dedicated selection lists the Tier 1 Rust
-cross-compilation targets (e.g. `aarch64-unknown-linux-gnu`,
-`x86_64-pc-windows-msvc`) as quick presets before the manual form appears.
-Leave a field blank to fall back to the detected defaults or mirror the ARM64
-prefix into the general `CROSS_COMPILE` setting.
+selected cross-compilers. The Rust target preset list is populated from
+`rustc --print target-list`, giving access to every target supported by the
+installed toolchain before the manual form appears. Leave a field blank to fall
+back to the detected defaults or mirror the ARM64 prefix into the general
+`CROSS_COMPILE` setting.
 
 ## Running the QEMU Environment
 


### PR DESCRIPTION
## Summary
- query `rustc --print target-list` to build the interactive menu of Rust target triples
- clamp the dialog height and reuse the queried triples when populating the selection list
- document that the presets now come from the installed toolchain's target list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d59427712c832fa6cbd8742bb1e4ec