### PR TITLE
Link linux_shims against libc

### DIFF
--- a/src/linux_shims/src/lib.rs
+++ b/src/linux_shims/src/lib.rs
@@ -3,6 +3,7 @@
 use core::ffi::{c_char, c_void};
 use core::sync::atomic::{AtomicBool, Ordering};
 
+#[link(name = "c")]
 extern "C" {
     fn vprintf(fmt: *const c_char, args: *mut c_void) -> i32;
 }


### PR DESCRIPTION
## Summary
- explicitly link linux_shims' C FFI block against libc so vprintf and other libc symbols resolve

## Testing
- cargo check --manifest-path src/linux_shims/Cargo.toml
