### PR TITLE
Handle armv8r musl staging

### DIFF
--- a/crates/l4re-libc/build.rs
+++ b/crates/l4re-libc/build.rs
@@ -56,6 +56,7 @@ fn resolve_musl_prefix() -> Option<PathBuf> {
     match target_arch.as_str() {
         "aarch64" => env_candidates.push("L4RE_LIBC_MUSL_PREFIX_ARM64".to_string()),
         "arm" => env_candidates.push("L4RE_LIBC_MUSL_PREFIX_ARM".to_string()),
+        "armv8r" => env_candidates.push("L4RE_LIBC_MUSL_PREFIX_ARM".to_string()),
         _ => {}
     }
     env_candidates.push("L4RE_LIBC_MUSL_PREFIX".to_string());
@@ -81,6 +82,7 @@ fn resolve_musl_prefix() -> Option<PathBuf> {
     let stage_arch = match target_arch.as_str() {
         "aarch64" => "arm64",
         "arm" => "arm",
+        "armv8r" => "arm",
         other => other,
     };
 
@@ -116,6 +118,7 @@ fn canonicalize(path: &Path) -> PathBuf {
 fn arch_uppercase_fallback(target_arch: &str) -> String {
     match target_arch {
         "aarch64" => "ARM64".to_string(),
+        "armv8r" => "ARM".to_string(),
         other => other.to_uppercase(),
     }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -160,6 +160,9 @@ prepare_rust_musl_environment() {
     arm)
       stage_arch="arm"
       ;;
+    armv8r)
+      stage_arch="arm"
+      ;;
     aarch64)
       stage_arch="arm64"
       ;;


### PR DESCRIPTION
## Summary
- treat the armv8r Rust target as using the 32-bit musl staging prefix in the build tooling
- allow the l4re-libc build script to fall back to the ARM musl prefix and staging directory when compiling for armv8r

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d5a5f59ecc832fa9faff6128ea7498