### PR TITLE
Trim musl staging to L4Re-specific shims

### DIFF
--- a/crates/l4re-libc/build.rs
+++ b/crates/l4re-libc/build.rs
@@ -1,15 +1,18 @@
 use std::{
+    collections::BTreeSet,
     env, fs,
     path::{Path, PathBuf},
 };
 
-const MUSL_LIBS: &[&str] = &["c", "pthread", "dl", "m", "rt", "resolv"];
+const MUSL_LIBS: &[&str] = &["c"];
+const L4RE_CORE_LIBS: &[&str] = &["pthread-l4", "l4re_c", "l4re_c-util"];
 
 fn main() {
     if env::var_os("CARGO_FEATURE_SYSCALL_FALLBACKS").is_some() {
         compile_syscall_wrappers();
     }
 
+    configure_l4re_core_linkage();
     configure_musl_linkage();
 }
 
@@ -22,6 +25,57 @@ fn compile_syscall_wrappers() {
     build.file("src/timerfd.c");
     build.file("src/inotify.c");
     build.compile("l4re_libc_c");
+}
+
+fn configure_l4re_core_linkage() {
+    println!("cargo:rerun-if-env-changed=L4RE_CORE_DIR");
+
+    let manifest_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
+    let default_core_dir = manifest_dir
+        .join("..")
+        .join("..")
+        .join("src")
+        .join("l4re-core");
+    let core_dir = env::var_os("L4RE_CORE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or(default_core_dir);
+
+    if !core_dir.exists() {
+        println!(
+            "cargo:warning=L4Re core directory '{}' does not exist; skipping core linkage",
+            core_dir.display()
+        );
+        return;
+    }
+
+    let candidate_dirs = discover_l4re_library_dirs(&core_dir);
+    if candidate_dirs.is_empty() {
+        println!(
+            "cargo:warning=Unable to locate any L4Re core library directories under '{}'",
+            core_dir.display()
+        );
+        return;
+    }
+
+    let mut linked = false;
+    for dir in candidate_dirs {
+        if ensure_libraries_present(&dir, L4RE_CORE_LIBS) {
+            println!("cargo:rustc-link-search=native={}", dir.display());
+            linked = true;
+        }
+    }
+
+    if linked {
+        for lib in L4RE_CORE_LIBS {
+            println!("cargo:rustc-link-lib={}", lib);
+        }
+    } else {
+        println!(
+            "cargo:warning=Failed to locate required L4Re core libraries ({}); builds may fail",
+            L4RE_CORE_LIBS.join(", ")
+        );
+    }
 }
 
 fn configure_musl_linkage() {
@@ -121,4 +175,85 @@ fn arch_uppercase_fallback(target_arch: &str) -> String {
         "armv8r" => "ARM".to_string(),
         other => other.to_uppercase(),
     }
+}
+
+fn discover_l4re_library_dirs(core_dir: &Path) -> Vec<PathBuf> {
+    let mut dirs = BTreeSet::new();
+
+    push_if_dir(&mut dirs, core_dir.to_path_buf());
+    for suffix in [
+        "lib",
+        "lib32",
+        "lib64",
+        "lib/arm",
+        "lib/aarch64",
+        "lib/amd64",
+        "lib/mips",
+        "lib/mips32",
+        "lib/mips64",
+        "lib/ppc32",
+        "lib/riscv",
+        "lib/riscv64",
+        "lib/x86",
+    ] {
+        push_if_dir(&mut dirs, core_dir.join(suffix));
+    }
+
+    if let Ok(entries) = fs::read_dir(core_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                push_if_dir(&mut dirs, path.join("lib"));
+                if let Ok(subdirs) = fs::read_dir(path.join("lib")) {
+                    for sub in subdirs.flatten() {
+                        push_if_dir(&mut dirs, sub.path());
+                    }
+                }
+            }
+        }
+    }
+
+    if let Ok(entries) = fs::read_dir(core_dir.join("lib")) {
+        for entry in entries.flatten() {
+            push_if_dir(&mut dirs, entry.path());
+        }
+    }
+
+    dirs.into_iter().collect()
+}
+
+fn push_if_dir(set: &mut BTreeSet<PathBuf>, path: PathBuf) {
+    if path.is_dir() {
+        set.insert(path);
+    }
+}
+
+fn ensure_libraries_present(dir: &Path, libs: &[&str]) -> bool {
+    libs.iter().all(|lib| library_exists(dir, lib))
+}
+
+fn library_exists(dir: &Path, lib: &str) -> bool {
+    let base = format!("lib{}", lib);
+    let static_path = dir.join(format!("{}.a", base));
+    if static_path.exists() {
+        return true;
+    }
+
+    let shared_path = dir.join(format!("{}.so", base));
+    if shared_path.exists() {
+        return true;
+    }
+
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let file_name = entry.file_name();
+            if let Some(name) = file_name.to_str() {
+                if name.starts_with(&format!("{}.so", base)) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
 }


### PR DESCRIPTION
## Summary
- prune the staged musl build down to the epoll/eventfd/signalfd/timerfd/inotify objects and park the full libc artifacts aside
- teach the l4re-libc build script to prefer pthread-l4, l4re_c, and l4re_c-util from the L4Re core before linking the trimmed musl archive
- document the new minimal musl packaging behaviour in the integration whitepaper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d610c88910832fb95aa95cf80b5c1e