### PR TITLE
Ensure nanosleep symbol survives musl minimisation

### DIFF
--- a/crates/l4re-libc/tests/musl_smoke.rs
+++ b/crates/l4re-libc/tests/musl_smoke.rs
@@ -15,6 +15,13 @@ fn musl_libc_available() {
             !ptr.is_null(),
             "dlsym failed to locate eventfd symbol via staged musl libc"
         );
+
+        let symbol = CString::new("nanosleep").unwrap();
+        let ptr = libc::dlsym(handle, symbol.as_ptr());
+        assert!(
+            !ptr.is_null(),
+            "dlsym failed to locate nanosleep symbol via staged musl libc"
+        );
         libc::dlclose(handle);
     }
 }

--- a/docs/musl_integration_whitepaper.md
+++ b/docs/musl_integration_whitepaper.md
@@ -42,7 +42,7 @@ pkg-config. Version markers (`VERSION`) are written to allow the incremental
 component logic to determine whether a rebuild is required.
 
 After installation the build helper now prunes the musl archive so that only
-the epoll, eventfd, signalfd, timerfd, and inotify entry points remain. The
+the epoll, eventfd, signalfd, timerfd, inotify, and nanosleep entry points remain. The
 script inspects `libc.a`, extracts the object files that define these symbols,
 and repackages them into a reduced archive while moving the full musl `libc`
 and dynamic loader aside. This ensures the staged runtime only provides the

--- a/scripts/build_musl.sh
+++ b/scripts/build_musl.sh
@@ -131,6 +131,7 @@ minimise_musl_libc() {
     epoll_ctl
     epoll_wait
     epoll_pwait
+    nanosleep
     signalfd
     signalfd4?
     timerfd_create
@@ -190,7 +191,7 @@ minimise_musl_libc() {
 
   rm -rf "$tmpdir"
   trap - RETURN
-  echo "Minimised musl libc archive to event/epoll/signalfd/timerfd/inotify symbols"
+  echo "Minimised musl libc archive to event/epoll/signalfd/timerfd/inotify/nanosleep symbols"
 }
 
 main() {


### PR DESCRIPTION
## Summary
- retain the nanosleep object when trimming the staged musl libc so Rust binaries can resolve the symbol
- document that nanosleep is part of the preserved musl surface
- extend the musl smoke test to assert nanosleep is exported

## Testing
- cargo test -p l4re-libc --test musl_smoke
