### PR TITLE
Fix minimal musl libc archive symbol coverage

### DIFF
--- a/scripts/build_musl.sh
+++ b/scripts/build_musl.sh
@@ -140,6 +140,14 @@ minimise_musl_libc() {
     inotify_init1
     inotify_add_watch
     inotify_rm_watch
+    __syscall
+    __syscall_cp
+    __syscall_ret
+    __block_all_sigs
+    __restore_sigs
+    __pthread_self
+    pthread_testcancel
+    libc
   )
 
   local objects


### PR DESCRIPTION
## Summary
- ensure the musl minimisation step retains syscall helper objects needed by the event/epoll/timerfd wrappers

## Testing
- not run (not applicable)
