### PR TITLE
Ensure pthread fallback when L4Re core libraries missing

### DIFF
--- a/crates/l4re-libc/build.rs
+++ b/crates/l4re-libc/build.rs
@@ -47,6 +47,7 @@ fn configure_l4re_core_linkage() {
             "cargo:warning=L4Re core directory '{}' does not exist; skipping core linkage",
             core_dir.display()
         );
+        link_system_pthread_fallback();
         return;
     }
 
@@ -56,6 +57,7 @@ fn configure_l4re_core_linkage() {
             "cargo:warning=Unable to locate any L4Re core library directories under '{}'",
             core_dir.display()
         );
+        link_system_pthread_fallback();
         return;
     }
 
@@ -74,6 +76,7 @@ fn configure_l4re_core_linkage() {
             "cargo:warning=Failed to locate required L4Re core libraries ({}); builds may fail",
             L4RE_CORE_REQUIRED_LIBS.join(", ")
         );
+        link_system_pthread_fallback();
         return;
     }
 


### PR DESCRIPTION
## Summary
- ensure the l4re-libc build script links against the system pthread library when L4Re core libraries are unavailable
- maintain existing warnings while preventing linker failures due to missing pthread symbols

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d6431fed7c832f97826b3e40f0a987