### PR TITLE
Apply Fiasco host patch for musl compatibility

### DIFF
--- a/scripts/patches/fiasco/0001-Disable-FORTIFY-for-host-tools-on-non-glibc-libcs.patch
+++ b/scripts/patches/fiasco/0001-Disable-FORTIFY-for-host-tools-on-non-glibc-libcs.patch
@@ -1,0 +1,20 @@
+diff --git a/src/Makeconf b/src/Makeconf
+index 81f0f1fd..454bd88b 100644
+--- a/src/Makeconf
++++ b/src/Makeconf
+@@ -275,6 +275,15 @@ HOST_CPPFLAGS   +=
+ HOST_CFLAGS     += -O2 -Wall -Wextra
+ HOST_CXXFLAGS   += -O2 -Wall -Wextra
+ 
++# Check whether the host compiler targets glibc. If it does not, disable the
++# glibc-specific FORTIFY entry points that musl and other libcs do not
++# provide so the host utilities link successfully.
++HOST_LIBC_IS_GLIBC := $(shell printf '#include <features.h>\n#ifdef __GLIBC__\nGLIBC\n#endif\n' | \
++        $(HOST_CC) -E - 2>/dev/null | grep -q GLIBC && echo 1 || echo 0)
++ifeq ($(HOST_LIBC_IS_GLIBC),0)
++HOST_CPPFLAGS   += -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
++endif
++
+ # for stddef.h, ...
+ GCCINCDIR       := $(shell $(filter-out $(CCACHE),$(CXX)) $(SHARED_FLAGS) $\
+                    -print-file-name=include)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -89,6 +89,17 @@ if [ "$cmd" != "clean" ]; then
         exit "$sync_status"
       fi
     fi
+
+    fiasco_patch_dir="$SCRIPT_DIR/patches/fiasco"
+    if [ -d "$fiasco_patch_dir" ] && [ -d fiasco ]; then
+      (
+        cd fiasco
+        for patch_file in "$fiasco_patch_dir"/*.patch; do
+          [ -e "$patch_file" ] || continue
+          patch -p1 -N <"$patch_file"
+        done
+      )
+    fi
   )
 fi
 


### PR DESCRIPTION
## Summary
- add a patch for the upstream Fiasco tree that disables glibc-specific FORTIFY symbols when building host utilities on musl-based systems
- update `scripts/setup.sh` to apply the Fiasco patch set after syncing the manifest

## Testing
- not run
