### PR TITLE
Fix musl loader pruning

### DIFF
--- a/docs/musl_integration_whitepaper.md
+++ b/docs/musl_integration_whitepaper.md
@@ -44,10 +44,12 @@ component logic to determine whether a rebuild is required.
 After installation the build helper now prunes the musl archive so that only
 the epoll, eventfd, signalfd, timerfd, inotify, and nanosleep entry points remain. The
 script inspects `libc.a`, extracts the object files that define these symbols,
-and repackages them into a reduced archive while moving the full musl `libc`
-and dynamic loader aside. This ensures the staged runtime only provides the
-handful of kernel interfaces that are absent from the L4Re core libraries,
-avoiding conflicts with the native `pthread-l4`, `l4re_c`, and `l4re_c-util`
+and repackages them into a reduced archive while keeping the original shared
+objects intact. The full static archive is preserved as `libc.full.a`, allowing
+consumers that require the complete musl runtime to access it explicitly while
+the default `libc.a` only exports the kernel helpers needed by L4Re. This
+ensures the staged runtime provides the handful of missing interfaces without
+conflicting with the native `pthread-l4`, `l4re_c`, and `l4re_c-util`
 implementations that ship with L4Re.
 
 ### Rust integration

--- a/scripts/build_musl.sh
+++ b/scripts/build_musl.sh
@@ -179,16 +179,6 @@ minimise_musl_libc() {
     return 1
   fi
 
-  if [ -f "$lib_dir/libc.so" ]; then
-    mv "$lib_dir/libc.so" "$lib_dir/libc.full.so"
-  fi
-
-  if ls "$lib_dir"/ld-musl-*.so.1 >/dev/null 2>&1; then
-    for loader in "$lib_dir"/ld-musl-*.so.1; do
-      mv "$loader" "$loader.full"
-    done
-  fi
-
   rm -rf "$tmpdir"
   trap - RETURN
   echo "Minimised musl libc archive to event/epoll/signalfd/timerfd/inotify/nanosleep symbols"


### PR DESCRIPTION
## Summary
- keep the musl shared libraries and dynamic loader in place when trimming the staged libc archive
- document that only the static archive is minimised and that the full copy is preserved separately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d663a526e8832fa11282f745080623