### PR TITLE
Guard L4Re crates on non-L4 targets

### DIFF
--- a/crates/l4-sys/build.rs
+++ b/crates/l4-sys/build.rs
@@ -1,7 +1,15 @@
-use std::env;
+use std::{env, fs};
 use std::path::PathBuf;
 
 fn main() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os != "l4re" {
+        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+        fs::write(out_path.join("bindings.rs"), "// l4_sys stubs for non-L4Re targets\n")
+            .expect("failed to write stub bindings");
+        return;
+    }
+
     let mut bindings = bindgen::Builder::default()
         .header("bindgen.h")
         .use_core()

--- a/crates/l4-sys/lib.rs
+++ b/crates/l4-sys/lib.rs
@@ -1,32 +1,53 @@
 #![no_std]
 
-#[cfg(not(any(target_arch = "aarch64", target_arch = "aarch32")))]
+#[cfg(target_os = "l4re")]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "arm")))]
 compile_error!("Only ARM architectures are supported.");
 
+#[cfg(target_os = "l4re")]
 #[macro_use]
 mod ipc_ext;
+#[cfg(target_os = "l4re")]
 mod c_api;
+#[cfg(target_os = "l4re")]
 mod cap;
+#[cfg(target_os = "l4re")]
 pub mod consts;
+#[cfg(target_os = "l4re")]
 mod factory;
+#[cfg(target_os = "l4re")]
 pub mod helpers;
+#[cfg(target_os = "l4re")]
 mod ipc_basic;
+#[cfg(target_os = "l4re")]
 mod platform;
+#[cfg(target_os = "l4re")]
 mod scheduler;
+#[cfg(target_os = "l4re")]
 mod task;
 
+#[cfg(target_os = "l4re")]
 pub use crate::c_api::*;
+#[cfg(target_os = "l4re")]
 /// expose public C API
 pub use crate::cap::*;
+#[cfg(target_os = "l4re")]
 pub use crate::factory::*;
+#[cfg(target_os = "l4re")]
 pub use crate::ipc_basic::*;
+#[cfg(target_os = "l4re")]
 pub use crate::ipc_ext::*;
+#[cfg(target_os = "l4re")]
 pub use crate::platform::*;
+#[cfg(target_os = "l4re")]
 pub use crate::scheduler::*;
+#[cfg(target_os = "l4re")]
 pub use crate::task::*;
 
+#[cfg(target_os = "l4re")]
 const L4_PAGEMASKU: l4_addr_t = L4_PAGEMASK as l4_addr_t;
 
+#[cfg(target_os = "l4re")]
 #[inline]
 pub fn trunc_page(address: l4_addr_t) -> l4_addr_t {
     address & L4_PAGEMASKU
@@ -36,17 +57,37 @@ pub fn trunc_page(address: l4_addr_t) -> l4_addr_t {
 ///
 /// The given address is rounded up to the next minimal page boundary. On most architectures this is a 4k
 /// page. Check `L4_PAGESIZE` for the minimal page size.
+#[cfg(target_os = "l4re")]
 #[inline]
 pub fn round_page(address: usize) -> l4_addr_t {
     ((address + L4_PAGESIZE as usize - 1usize) & (L4_PAGEMASK as usize)) as l4_addr_t
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_os = "l4re", target_arch = "aarch64"))]
 pub type L4Umword = u64;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_os = "l4re", target_arch = "aarch64"))]
 pub type L4Mword = i64;
 
-#[cfg(target_arch = "aarch32")]
+#[cfg(all(target_os = "l4re", target_arch = "arm"))]
 pub type L4Umword = u32;
-#[cfg(target_arch = "aarch32")]
+#[cfg(all(target_os = "l4re", target_arch = "arm"))]
 pub type L4Mword = i32;
+
+#[cfg(not(target_os = "l4re"))]
+#[allow(non_camel_case_types)]
+mod stub {
+    pub type l4_addr_t = usize;
+
+    #[inline]
+    pub fn trunc_page(address: l4_addr_t) -> l4_addr_t {
+        address & !0xfff
+    }
+
+    #[inline]
+    pub fn round_page(address: usize) -> l4_addr_t {
+        address as l4_addr_t
+    }
+}
+
+#[cfg(not(target_os = "l4re"))]
+pub use stub::*;

--- a/crates/l4/build.rs
+++ b/crates/l4/build.rs
@@ -1,6 +1,9 @@
 use std::env;
 
 fn main() {
+    if env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "l4re" {
+        return;
+    }
     let mut build = cc::Build::new();
     build.file("ipc/syscall.c");
     if let Ok(include_dirs) = env::var("L4_INCLUDE_DIRS") {

--- a/crates/l4/lib.rs
+++ b/crates/l4/lib.rs
@@ -2,35 +2,62 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(target_os = "l4re")]
 #[macro_use]
 extern crate bitflags;
+#[cfg(target_os = "l4re")]
 #[macro_use]
 extern crate num_derive;
+#[cfg(target_os = "l4re")]
 extern crate num_traits;
 
 // apart from macro_use, keep this alphabetical
+#[cfg(target_os = "l4re")]
 #[macro_use]
 pub mod types;
+#[cfg(target_os = "l4re")]
 #[macro_use]
 pub mod error;
+#[cfg(target_os = "l4re")]
 #[macro_use]
 pub mod utcb;
+#[cfg(target_os = "l4re")]
 pub mod cap;
+#[cfg(target_os = "l4re")]
 pub mod ipc;
-#[cfg(not(feature = "std"))]
+#[cfg(all(target_os = "l4re", not(feature = "std")))]
 #[macro_use]
 pub mod nostd_helper;
+#[cfg(target_os = "l4re")]
 pub mod task;
 
-#[cfg(feature = "scheduler")]
+#[cfg(all(target_os = "l4re", feature = "scheduler"))]
 pub mod scheduler;
 
-#[cfg(feature = "scheduler")]
+#[cfg(all(target_os = "l4re", feature = "scheduler"))]
 pub use scheduler::{SchedulerKind, SchedulerPolicy};
 
+#[cfg(target_os = "l4re")]
 pub use crate::error::{Error, Result};
+#[cfg(target_os = "l4re")]
 pub use crate::utcb::*;
 
+#[cfg(target_os = "l4re")]
 pub mod sys {
     pub use l4_sys::*;
 }
+
+#[cfg(not(target_os = "l4re"))]
+pub mod sys {}
+
+#[cfg(not(target_os = "l4re"))]
+pub mod host {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Unsupported;
+
+    pub type Error = Unsupported;
+    pub type Result<T> = core::result::Result<T, Unsupported>;
+}
+
+#[cfg(not(target_os = "l4re"))]
+pub use host::{Error, Result};

--- a/crates/l4re/build.rs
+++ b/crates/l4re/build.rs
@@ -1,7 +1,13 @@
-use std::env;
+use std::{env, fs};
 use std::path::PathBuf;
 
 fn main() {
+    if env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "l4re" {
+        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+        fs::write(out_path.join("bindings.rs"), "// l4re stubs for non-L4Re targets\n")
+            .expect("failed to write stub bindings");
+        return;
+    }
     let mut bindings = bindgen::Builder::default()
         .use_core()
         .ctypes_prefix("core::ffi")

--- a/crates/l4re/lib.rs
+++ b/crates/l4re/lib.rs
@@ -3,9 +3,17 @@
 //! Reimplemented methods
 #![no_std]
 
+#[cfg(target_os = "l4re")]
 mod cap;
+#[cfg(target_os = "l4re")]
 pub mod env;
+#[cfg(target_os = "l4re")]
 pub mod mem;
+#[cfg(target_os = "l4re")]
 pub mod sys;
 
+#[cfg(target_os = "l4re")]
 pub use cap::OwnedCap;
+
+#[cfg(not(target_os = "l4re"))]
+pub struct OwnedCap;

--- a/crates/net-client/src/lib.rs
+++ b/crates/net-client/src/lib.rs
@@ -1,140 +1,156 @@
 #![no_std]
 
-//! Simple client library for the `global_net` network service.
-//!
-//! # Message register layout
-//!
-//! All operations use the first message register (`MR0`) to denote the
-//! operation code. Additional registers carry operation specific
-//! arguments as documented below:
-//!
-//! ```text
-//! MR0: operation code
-//!
-//! Socket open (OP_OPEN)
-//!   MR1: protocol (0 = UDP)
-//!   Reply: MR0 = socket handle
-//!
-//! Socket send (OP_SEND)
-//!   MR1: socket handle
-//!   MR2: length in bytes
-//!   MR3..: payload (truncated to available registers)
-//!   Reply: MR0 = status (0 = ok)
-//!
-//! Socket receive (OP_RECV)
-//!   MR1: socket handle
-//!   MR2: buffer capacity
-//!   Reply: MR0 = bytes received
-//!   MR1..: payload
-//!
-//! Socket close (OP_CLOSE)
-//!   MR1: socket handle
-//!   Reply: MR0 = status (0 = ok)
-//! ```
-//!
-//! The functions provided here implement these operations for small
-//! messages entirely transmitted via the message registers. They are
-//! intended as a starting point for more fully fledged networking
-//! support.
+#[cfg(target_os = "l4re")]
+mod implementation {
+    //! Simple client library for the `global_net` network service.
+    //!
+    //! # Message register layout
+    //!
+    //! All operations use the first message register (`MR0`) to denote the
+    //! operation code. Additional registers carry operation specific
+    //! arguments as documented below:
+    //!
+    //! ```text
+    //! MR0: operation code
+    //!
+    //! Socket open (OP_OPEN)
+    //!   MR1: protocol (0 = UDP)
+    //!   Reply: MR0 = socket handle
+    //!
+    //! Socket send (OP_SEND)
+    //!   MR1: socket handle
+    //!   MR2: length in bytes
+    //!   MR3..: payload (truncated to available registers)
+    //!   Reply: MR0 = status (0 = ok)
+    //!
+    //! Socket receive (OP_RECV)
+    //!   MR1: socket handle
+    //!   MR2: buffer capacity
+    //!   Reply: MR0 = bytes received
+    //!   MR1..: payload
+    //!
+    //! Socket close (OP_CLOSE)
+    //!   MR1: socket handle
+    //!   Reply: MR0 = status (0 = ok)
+    //! ```
+    //!
+    //! The functions provided here implement these operations for small
+    //! messages entirely transmitted via the message registers. They are
+    //! intended as a starting point for more fully fledged networking
+    //! support.
 
-use l4re::sys::l4re_env_get_cap;
-use l4::sys::{l4_ipc_call, l4_ipc_error, l4_msgtag, l4_utcb};
+    use l4re::sys::l4re_env_get_cap;
+    use l4::sys::{l4_ipc_call, l4_ipc_error, l4_msgtag, l4_utcb};
 
-/// Operation code: open a socket.
-pub const OP_OPEN: u64 = 0;
-/// Operation code: send data.
-pub const OP_SEND: u64 = 1;
-/// Operation code: receive data.
-pub const OP_RECV: u64 = 2;
-/// Operation code: close a socket.
-pub const OP_CLOSE: u64 = 3;
+    /// Operation code: open a socket.
+    pub const OP_OPEN: u64 = 0;
+    /// Operation code: send data.
+    pub const OP_SEND: u64 = 1;
+    /// Operation code: receive data.
+    pub const OP_RECV: u64 = 2;
+    /// Operation code: close a socket.
+    pub const OP_CLOSE: u64 = 3;
 
-/// Client handle to the network service.
-pub struct NetClient {
-    gate: l4re::sys::l4_cap_idx_t,
+    /// Client handle to the network service.
+    pub struct NetClient {
+        gate: l4re::sys::l4_cap_idx_t,
+    }
+
+    impl NetClient {
+        /// Retrieve the `global_net` capability from the environment.
+        pub fn new() -> Option<Self> {
+            l4re_env_get_cap("global_net").map(|gate| NetClient { gate })
+        }
+
+        /// Request a UDP socket from the server.
+        pub fn open_socket(&self) -> Result<u64, i32> {
+            unsafe {
+                (*l4::sys::l4_utcb_mr()).mr[0] = OP_OPEN;
+                (*l4::sys::l4_utcb_mr()).mr[1] = 0; // protocol: UDP
+                let tag = l4_ipc_call(
+                    self.gate,
+                    l4_utcb(),
+                    l4_msgtag(0, 2, 0, 0),
+                    l4::sys::l4_timeout_t { raw: 0 },
+                );
+                let err = l4_ipc_error(tag, l4_utcb());
+                if err != 0 {
+                    return Err(err);
+                }
+                Ok((*l4::sys::l4_utcb_mr()).mr[0])
+            }
+        }
+
+        /// Send a single word of data to the server.
+        pub fn send(&self, handle: u64, word: u64) -> Result<(), i32> {
+            unsafe {
+                (*l4::sys::l4_utcb_mr()).mr[0] = OP_SEND;
+                (*l4::sys::l4_utcb_mr()).mr[1] = handle;
+                (*l4::sys::l4_utcb_mr()).mr[2] = word;
+                let tag = l4_ipc_call(
+                    self.gate,
+                    l4_utcb(),
+                    l4_msgtag(0, 3, 0, 0),
+                    l4::sys::l4_timeout_t { raw: 0 },
+                );
+                let err = l4_ipc_error(tag, l4_utcb());
+                if err != 0 {
+                    return Err(err);
+                }
+                Ok(())
+            }
+        }
+
+        /// Receive a single word of data from the server.
+        pub fn recv(&self, handle: u64) -> Result<u64, i32> {
+            unsafe {
+                (*l4::sys::l4_utcb_mr()).mr[0] = OP_RECV;
+                (*l4::sys::l4_utcb_mr()).mr[1] = handle;
+                let tag = l4_ipc_call(
+                    self.gate,
+                    l4_utcb(),
+                    l4_msgtag(0, 2, 0, 0),
+                    l4::sys::l4_timeout_t { raw: 0 },
+                );
+                let err = l4_ipc_error(tag, l4_utcb());
+                if err != 0 {
+                    return Err(err);
+                }
+                Ok((*l4::sys::l4_utcb_mr()).mr[0])
+            }
+        }
+
+        /// Close the socket.
+        pub fn close(&self, handle: u64) -> Result<(), i32> {
+            unsafe {
+                (*l4::sys::l4_utcb_mr()).mr[0] = OP_CLOSE;
+                (*l4::sys::l4_utcb_mr()).mr[1] = handle;
+                let tag = l4_ipc_call(
+                    self.gate,
+                    l4_utcb(),
+                    l4_msgtag(0, 2, 0, 0),
+                    l4::sys::l4_timeout_t { raw: 0 },
+                );
+                let err = l4_ipc_error(tag, l4_utcb());
+                if err != 0 {
+                    return Err(err);
+                }
+                Ok(())
+            }
+        }
+    }
 }
 
+#[cfg(target_os = "l4re")]
+pub use implementation::*;
+
+#[cfg(not(target_os = "l4re"))]
+pub struct NetClient;
+
+#[cfg(not(target_os = "l4re"))]
 impl NetClient {
-    /// Retrieve the `global_net` capability from the environment.
     pub fn new() -> Option<Self> {
-        l4re_env_get_cap("global_net").map(|gate| NetClient { gate })
-    }
-
-    /// Request a UDP socket from the server.
-    pub fn open_socket(&self) -> Result<u64, i32> {
-        unsafe {
-            (*l4::sys::l4_utcb_mr()).mr[0] = OP_OPEN;
-            (*l4::sys::l4_utcb_mr()).mr[1] = 0; // protocol: UDP
-            let tag = l4_ipc_call(
-                self.gate,
-                l4_utcb(),
-                l4_msgtag(0, 2, 0, 0),
-                l4::sys::l4_timeout_t { raw: 0 },
-            );
-            let err = l4_ipc_error(tag, l4_utcb());
-            if err != 0 {
-                return Err(err);
-            }
-            Ok((*l4::sys::l4_utcb_mr()).mr[0])
-        }
-    }
-
-    /// Send a single word of data to the server.
-    pub fn send(&self, handle: u64, word: u64) -> Result<(), i32> {
-        unsafe {
-            (*l4::sys::l4_utcb_mr()).mr[0] = OP_SEND;
-            (*l4::sys::l4_utcb_mr()).mr[1] = handle;
-            (*l4::sys::l4_utcb_mr()).mr[2] = word;
-            let tag = l4_ipc_call(
-                self.gate,
-                l4_utcb(),
-                l4_msgtag(0, 3, 0, 0),
-                l4::sys::l4_timeout_t { raw: 0 },
-            );
-            let err = l4_ipc_error(tag, l4_utcb());
-            if err != 0 {
-                return Err(err);
-            }
-            Ok(())
-        }
-    }
-
-    /// Receive a single word of data from the server.
-    pub fn recv(&self, handle: u64) -> Result<u64, i32> {
-        unsafe {
-            (*l4::sys::l4_utcb_mr()).mr[0] = OP_RECV;
-            (*l4::sys::l4_utcb_mr()).mr[1] = handle;
-            let tag = l4_ipc_call(
-                self.gate,
-                l4_utcb(),
-                l4_msgtag(0, 2, 0, 0),
-                l4::sys::l4_timeout_t { raw: 0 },
-            );
-            let err = l4_ipc_error(tag, l4_utcb());
-            if err != 0 {
-                return Err(err);
-            }
-            Ok((*l4::sys::l4_utcb_mr()).mr[0])
-        }
-    }
-
-    /// Close the socket.
-    pub fn close(&self, handle: u64) -> Result<(), i32> {
-        unsafe {
-            (*l4::sys::l4_utcb_mr()).mr[0] = OP_CLOSE;
-            (*l4::sys::l4_utcb_mr()).mr[1] = handle;
-            let tag = l4_ipc_call(
-                self.gate,
-                l4_utcb(),
-                l4_msgtag(0, 2, 0, 0),
-                l4::sys::l4_timeout_t { raw: 0 },
-            );
-            let err = l4_ipc_error(tag, l4_utcb());
-            if err != 0 {
-                return Err(err);
-            }
-            Ok(())
-        }
+        None
     }
 }
 


### PR DESCRIPTION
## Summary
- skip generating L4Re bindings on non-L4 targets and emit harmless stubs instead
- gate the l4 and l4re libraries behind `target_os = "l4re"`, providing lightweight placeholders for host builds
- wrap the net-client implementation in an L4Re-only module while keeping a stub constructor elsewhere

## Testing
- cargo build --workspace
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d6d3821da8832fbcb98b17d04a2da5