### PR TITLE
Allow distinct cross-compilers for ARM and ARM64 builds

### DIFF
--- a/scripts/common_build.sh
+++ b/scripts/common_build.sh
@@ -52,9 +52,11 @@ sync_cross_compile_variables() {
     fi
   fi
 
-  CROSS_COMPILE="$primary"
-  CROSS_COMPILE_ARM="$primary"
-  CROSS_COMPILE_ARM64="$primary"
+  if [ -n "$primary" ]; then
+    CROSS_COMPILE="${CROSS_COMPILE:-$primary}"
+    CROSS_COMPILE_ARM="${CROSS_COMPILE_ARM:-$primary}"
+    CROSS_COMPILE_ARM64="${CROSS_COMPILE_ARM64:-$primary}"
+  fi
 
   export CROSS_COMPILE CROSS_COMPILE_ARM CROSS_COMPILE_ARM64
 }


### PR DESCRIPTION
## Summary
- prevent sync_cross_compile_variables from overwriting architecture-specific cross compiler prefixes
- ensure missing prefixes fall back to a shared default without clobbering explicit settings

## Testing
- not run
