### PR TITLE
Fix cross configure invocation

### DIFF
--- a/scripts/build_bash.sh
+++ b/scripts/build_bash.sh
@@ -151,7 +151,7 @@ main() {
       )
     fi
 
-    "${configure_env[@]}" ./configure --host="$host" --build="$build_machine" --without-bash-malloc
+    env "${configure_env[@]}" ./configure --host="$host" --build="$build_machine" --without-bash-malloc
 
 
     local build_cflags_for_build


### PR DESCRIPTION
## Summary
- ensure bash build script launches configure with environment variables using `env`
- prevent shells from treating the cross-compiler assignment as a command when running configure

## Testing
- not run
