### PR TITLE
fix: force bash configure cache for bash

### DIFF
--- a/scripts/build_bash.sh
+++ b/scripts/build_bash.sh
@@ -148,6 +148,10 @@ main() {
     if [ "$host" != "$build_machine" ]; then
       configure_env+=(
         "ac_cv_exeext="
+        "ac_cv_prog_cc_cross=yes"
+        "ac_cv_prog_cc_works=yes"
+        "ac_cv_prog_cxx_cross=yes"
+        "ac_cv_prog_cxx_works=yes"
       )
     fi
 


### PR DESCRIPTION
## Summary
- seed autoconf cache variables when the cross and build triples differ so bash's configure script skips executing test binaries during cross builds

## Testing
- not run (relies on downloading upstream bash sources)
