### PR TITLE
Skip Fiasco setup when component disabled

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -370,6 +370,12 @@ else
   done
 fi
 
+if should_build_component "fiasco"; then
+  unset L4RERUST_SKIP_FIASCO_SETUP
+else
+  export L4RERUST_SKIP_FIASCO_SETUP=1
+fi
+
 if [ "$clean_cli_override" = "no-clean" ]; then
   clean=false
 elif [ "$clean_cli_override" = "clean" ]; then


### PR DESCRIPTION
## Summary
- export an environment flag from the build menu flow when the Fiasco component is deselected
- have setup.sh honor the flag and skip running the Fiasco build directory creation step

## Testing
- not run (not requested)

