### PR TITLE
Add asynchronous I/O server and libc bindings

### DIFF
--- a/config/cfg/bash.cfg
+++ b/config/cfg/bash.cfg
@@ -4,6 +4,9 @@ local ld = L4.default_loader
 -- Allocate communication channels for system-wide services
 local fs_chan = ld:new_channel()
 local net_chan = ld:new_channel()
+local epoll_chan = ld:new_channel()
+local fd_chan = ld:new_channel()
+local aio_chan = ld:new_channel()
 local lsb_root = ld:new_channel()
 
 -- Start systemd (/sbin/init) and export capability handles so that
@@ -15,6 +18,9 @@ ld:start({
     global_fs = fs_chan:svr(),
     -- server side of the global network gate
     global_net = net_chan:svr(),
+    global_epoll = epoll_chan:svr(),
+    global_fd = fd_chan:svr(),
+    global_aio = aio_chan:svr(),
     -- server side of the LSB root gate
     lsb_root = lsb_root:svr(),
     -- provide hardware device and kernel interfaces for services

--- a/config/lsb_root/lib/systemd/system/aio_server.service
+++ b/config/lsb_root/lib/systemd/system/aio_server.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=L4Re AIO Server
+
+[Service]
+ExecStart=/boot/aio_server
+Environment="L4_CAP_GLOBAL_AIO=global_aio"
+CapabilityBoundingSet=
+AmbientCapabilities=
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/config/lsb_root/lib/systemd/system/epoll_server.service
+++ b/config/lsb_root/lib/systemd/system/epoll_server.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=L4Re Epoll Server
+
+[Service]
+ExecStart=/boot/epoll_server
+Environment="L4_CAP_GLOBAL_EPOLL=global_epoll"
+CapabilityBoundingSet=
+AmbientCapabilities=
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/config/lsb_root/lib/systemd/system/fd_server.service
+++ b/config/lsb_root/lib/systemd/system/fd_server.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=L4Re descriptor helper server
+After=fs_server.service
+Requires=fs_server.service
+
+[Service]
+ExecStart=/boot/fd_server
+Environment="L4_CAP_GLOBAL_FD=global_fd"
+
+[Install]
+WantedBy=multi-user.target

--- a/config/systemd/aio_server.service
+++ b/config/systemd/aio_server.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=L4Re AIO Server
+
+[Service]
+ExecStart=/boot/aio_server
+Environment="L4_CAP_GLOBAL_AIO=global_aio"
+CapabilityBoundingSet=
+AmbientCapabilities=
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/config/systemd/epoll_server.service
+++ b/config/systemd/epoll_server.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=L4Re Epoll Server
+
+[Service]
+ExecStart=/boot/epoll_server
+Environment="L4_CAP_GLOBAL_EPOLL=global_epoll"
+CapabilityBoundingSet=
+AmbientCapabilities=
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/config/systemd/fd_server.service
+++ b/config/systemd/fd_server.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=L4Re descriptor helper server
+After=fs_server.service
+Requires=fs_server.service
+
+[Service]
+ExecStart=/boot/fd_server
+Environment="L4_CAP_GLOBAL_FD=global_fd"
+
+[Install]
+WantedBy=multi-user.target

--- a/crates/l4re-libc/build.rs
+++ b/crates/l4re-libc/build.rs
@@ -1,10 +1,12 @@
 fn main() {
     let mut build = cc::Build::new();
     build.include("include");
+    build.include("../../src/l4rust/libl4re-wrapper/include");
     build.file("src/epoll.c");
     build.file("src/eventfd.c");
     build.file("src/signalfd.c");
     build.file("src/timerfd.c");
     build.file("src/inotify.c");
+    build.file("src/aio.c");
     build.compile("l4re_libc_c");
 }

--- a/crates/l4re-libc/src/aio.c
+++ b/crates/l4re-libc/src/aio.c
@@ -1,0 +1,390 @@
+#include <aio.h>
+#include <errno.h>
+#include "ipc.h"
+#include "env.h"
+#include <l4/sys/ipc.h>
+#include <l4/sys/utcb.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define OPCODE_AIO_READ   0
+#define OPCODE_AIO_WRITE  1
+#define OPCODE_AIO_ERROR  2
+#define OPCODE_AIO_RETURN 3
+#define OPCODE_AIO_CANCEL 4
+#define OPCODE_AIO_SUSPEND 5
+#define OPCODE_AIO_FSYNC  6
+
+#define BR_WORDS L4_UTCB_GENERIC_BUFFERS_SIZE
+#define BR_DATA_BYTES ((BR_WORDS - 1) * sizeof(l4_umword_t))
+
+struct aio_mapping {
+    const struct aiocb *cb;
+    unsigned long handle;
+    struct aio_mapping *next;
+};
+
+static pthread_mutex_t map_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct aio_mapping *aio_head = NULL;
+static l4_cap_idx_t aio_gate = L4_INVALID_CAP;
+
+static void clear_br(void)
+{
+    l4_buf_regs_t *br = l4_utcb_br();
+    br->br[0] = 0;
+}
+
+static struct aio_mapping *find_mapping(const struct aiocb *cb)
+{
+    struct aio_mapping *cur = aio_head;
+    while (cur) {
+        if (cur->cb == cb)
+            return cur;
+        cur = cur->next;
+    }
+    return NULL;
+}
+
+static void insert_mapping(const struct aiocb *cb, unsigned long handle)
+{
+    struct aio_mapping *node = malloc(sizeof(*node));
+    if (!node)
+        return;
+    node->cb = cb;
+    node->handle = handle;
+    node->next = aio_head;
+    aio_head = node;
+}
+
+static unsigned long remove_mapping(const struct aiocb *cb)
+{
+    struct aio_mapping **pp = &aio_head;
+    while (*pp) {
+        if ((*pp)->cb == cb) {
+            struct aio_mapping *node = *pp;
+            unsigned long handle = node->handle;
+            *pp = node->next;
+            free(node);
+            return handle;
+        }
+        pp = &(*pp)->next;
+    }
+    return 0;
+}
+
+static int ensure_gate(void)
+{
+    if (!l4_is_invalid_cap(aio_gate))
+        return 0;
+
+    l4_cap_idx_t gate = l4re_env_get_cap_w("global_aio");
+    if (l4_is_invalid_cap(gate))
+        return ENOENT;
+    aio_gate = gate;
+    return 0;
+}
+
+static long ipc_call(unsigned words)
+{
+    l4_utcb_t *utcb = l4_utcb_w();
+    l4_msgtag_t tag = l4_ipc_call_w(aio_gate, utcb, l4_msgtag_w(0, words, 0, 0), L4_IPC_NEVER);
+    long err = (long)l4_ipc_error_w(tag, utcb);
+    if (err)
+        return -EIO;
+    return 0;
+}
+
+static int submit_request(struct aiocb *cb, int opcode, const void *payload,
+                          size_t payload_len, unsigned long extra)
+{
+    int rc = ensure_gate();
+    if (rc)
+        return rc;
+
+    size_t struct_len = sizeof(*cb);
+    if (struct_len + payload_len > BR_DATA_BYTES)
+        return EOVERFLOW;
+
+    l4_msg_regs_t *mr = l4_utcb_mr_w();
+    l4_buf_regs_t *br = l4_utcb_br();
+    unsigned char *dst = (unsigned char *)(br->br + 1);
+    memcpy(dst, cb, struct_len);
+    if (payload_len)
+        memcpy(dst + struct_len, payload, payload_len);
+    br->br[0] = struct_len + payload_len;
+
+    mr->mr[0] = opcode;
+    mr->mr[1] = struct_len;
+    mr->mr[2] = payload_len;
+    mr->mr[3] = extra;
+
+    long status = ipc_call(4);
+    if (status < 0) {
+        clear_br();
+        return -status;
+    }
+
+    long long result = (long long)mr->mr[0];
+    if (result < 0) {
+        clear_br();
+        return (int)(-result);
+    }
+
+    insert_mapping(cb, (unsigned long)mr->mr[0]);
+    clear_br();
+    return 0;
+}
+
+static int call_simple(int opcode, unsigned long handle, long long *result, unsigned long *aux)
+{
+    int rc = ensure_gate();
+    if (rc)
+        return rc;
+
+    l4_msg_regs_t *mr = l4_utcb_mr_w();
+    mr->mr[0] = opcode;
+    mr->mr[1] = handle;
+
+    long status = ipc_call(2);
+    if (status < 0)
+        return -status;
+
+    long long value = (long long)mr->mr[0];
+    if (value < 0)
+        return (int)(-value);
+
+    if (result)
+        *result = value;
+    if (aux)
+        *aux = mr->mr[1];
+    return 0;
+}
+
+int aio_read(struct aiocb *cb)
+{
+    if (!cb)
+        return errno = EINVAL, -1;
+
+    pthread_mutex_lock(&map_lock);
+    int rc = submit_request(cb, OPCODE_AIO_READ, NULL, 0, 0);
+    pthread_mutex_unlock(&map_lock);
+
+    if (rc) {
+        errno = rc;
+        return -1;
+    }
+    return 0;
+}
+
+int aio_write(struct aiocb *cb)
+{
+    if (!cb)
+        return errno = EINVAL, -1;
+
+    pthread_mutex_lock(&map_lock);
+    const void *buf = cb->aio_buf;
+    size_t len = cb->aio_nbytes;
+    int rc = submit_request(cb, OPCODE_AIO_WRITE, buf, len, 0);
+    pthread_mutex_unlock(&map_lock);
+
+    if (rc) {
+        errno = rc;
+        return -1;
+    }
+    return 0;
+}
+
+int aio_fsync(int op, struct aiocb *cb)
+{
+    if (!cb)
+        return errno = EINVAL, -1;
+
+    pthread_mutex_lock(&map_lock);
+    int rc = submit_request(cb, OPCODE_AIO_FSYNC, NULL, 0, (unsigned long)op);
+    pthread_mutex_unlock(&map_lock);
+
+    if (rc) {
+        errno = rc;
+        return -1;
+    }
+    return 0;
+}
+
+int aio_error(const struct aiocb *cb)
+{
+    if (!cb)
+        return EINVAL;
+
+    pthread_mutex_lock(&map_lock);
+    struct aio_mapping *entry = find_mapping(cb);
+    unsigned long handle = entry ? entry->handle : 0;
+    pthread_mutex_unlock(&map_lock);
+
+    if (!handle)
+        return EINVAL;
+
+    long long value = 0;
+    int rc = call_simple(OPCODE_AIO_ERROR, handle, &value, NULL);
+    if (rc)
+        return rc;
+    return (int)value;
+}
+
+ssize_t aio_return(struct aiocb *cb)
+{
+    if (!cb)
+        return errno = EINVAL, -1;
+
+    pthread_mutex_lock(&map_lock);
+    unsigned long handle = remove_mapping(cb);
+    pthread_mutex_unlock(&map_lock);
+
+    if (!handle)
+        return errno = EINVAL, -1;
+
+    unsigned long aux = 0;
+    long long value = 0;
+    int rc = call_simple(OPCODE_AIO_RETURN, handle, &value, &aux);
+    if (rc) {
+        errno = rc;
+        return -1;
+    }
+
+    if (aux > 0 && cb->aio_buf) {
+        l4_buf_regs_t *br = l4_utcb_br();
+        size_t available = br->br[0];
+        if (available > aux)
+            available = aux;
+        memcpy(cb->aio_buf, (unsigned char *)(br->br + 1), available);
+    }
+    clear_br();
+    return (ssize_t)value;
+}
+
+int aio_cancel(int fd, struct aiocb *cb)
+{
+    (void)fd;
+    if (!cb)
+        return AIO_ALLDONE;
+
+    pthread_mutex_lock(&map_lock);
+    unsigned long handle = remove_mapping(cb);
+    pthread_mutex_unlock(&map_lock);
+
+    if (!handle)
+        return AIO_ALLDONE;
+
+    int rc = call_simple(OPCODE_AIO_CANCEL, handle, NULL, NULL);
+    if (rc)
+        return rc;
+    return AIO_ALLDONE;
+}
+
+int aio_suspend(const struct aiocb *const list[], int nent, const struct timespec *ts)
+{
+    (void)ts;
+    if (nent < 0)
+        return errno = EINVAL, -1;
+    if (!list || nent == 0)
+        return 0;
+
+    pthread_mutex_lock(&map_lock);
+    size_t count = 0;
+    for (int i = 0; i < nent; ++i) {
+        if (!list[i])
+            continue;
+        if (find_mapping(list[i]))
+            count++;
+    }
+    unsigned long *handles = calloc(count ? count : 1, sizeof(unsigned long));
+    if (!handles) {
+        pthread_mutex_unlock(&map_lock);
+        errno = ENOMEM;
+        return -1;
+    }
+    size_t pos = 0;
+    for (int i = 0; i < nent; ++i) {
+        if (!list[i])
+            continue;
+        struct aio_mapping *entry = find_mapping(list[i]);
+        if (entry)
+            handles[pos++] = entry->handle;
+    }
+    pthread_mutex_unlock(&map_lock);
+
+    int rc = 0;
+    if (pos) {
+        rc = ensure_gate();
+        if (!rc) {
+            if (pos * sizeof(unsigned long) > BR_DATA_BYTES)
+                rc = EOVERFLOW;
+            else {
+                l4_buf_regs_t *br = l4_utcb_br();
+                memcpy((unsigned char *)(br->br + 1), handles, pos * sizeof(unsigned long));
+                br->br[0] = pos * sizeof(unsigned long);
+                l4_msg_regs_t *mr = l4_utcb_mr_w();
+                mr->mr[0] = OPCODE_AIO_SUSPEND;
+                mr->mr[1] = pos;
+                long status = ipc_call(2);
+                if (status < 0)
+                    rc = -status;
+                else if ((long long)mr->mr[0] < 0)
+                    rc = (int)(-(long long)mr->mr[0]);
+                clear_br();
+            }
+        }
+    }
+    free(handles);
+    if (rc) {
+        errno = rc;
+        return -1;
+    }
+    return 0;
+}
+
+int lio_listio(int mode, struct aiocb *const list[], int nent, struct sigevent *sig)
+{
+    (void)sig;
+    if (nent < 0)
+        return errno = EINVAL, -1;
+    if (!list)
+        return 0;
+
+    for (int i = 0; i < nent; ++i) {
+        struct aiocb *cb = list[i];
+        if (!cb)
+            continue;
+        int rc;
+        switch (cb->aio_lio_opcode) {
+        case LIO_WRITE:
+            rc = aio_write(cb);
+            break;
+        case LIO_READ:
+            rc = aio_read(cb);
+            break;
+        case LIO_NOP:
+            rc = 0;
+            break;
+        default:
+            errno = EINVAL;
+            return -1;
+        }
+        if (rc) {
+            return -1;
+        }
+    }
+
+    if (mode == LIO_WAIT) {
+        for (int i = 0; i < nent; ++i) {
+            struct aiocb *cb = list[i];
+            if (!cb)
+                continue;
+            while (aio_error(cb) == EINPROGRESS) {
+                /* busy wait */
+            }
+        }
+    }
+    return 0;
+}

--- a/pkg/aio_server/Makefile
+++ b/pkg/aio_server/Makefile
@@ -1,0 +1,9 @@
+PKGDIR ?= .
+L4DIR ?= $(PKGDIR)/../..
+
+TARGET := aio_server
+
+install:: $(TARGET)
+$(INSTALL) -m 755 $(TARGET) $(INSTDIR)/boot/
+
+include $(L4DIR)/mk/subdir.mk

--- a/pkg/epoll_server/Makefile
+++ b/pkg/epoll_server/Makefile
@@ -1,0 +1,9 @@
+PKGDIR ?= .
+L4DIR ?= $(PKGDIR)/../..
+
+TARGET := epoll_server
+
+install:: $(TARGET)
+	$(INSTALL) -m 755 $(TARGET) $(INSTDIR)/boot/
+
+include $(L4DIR)/mk/subdir.mk

--- a/pkg/fd_server/Makefile
+++ b/pkg/fd_server/Makefile
@@ -1,0 +1,9 @@
+PKGDIR ?= .
+L4DIR ?= $(PKGDIR)/../..
+
+TARGET := fd_server
+
+install:: $(TARGET)
+$(INSTALL) -m 755 $(TARGET) $(INSTDIR)/boot/
+
+include $(L4DIR)/mk/subdir.mk

--- a/src/aio_server/Cargo.toml
+++ b/src/aio_server/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "aio_server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+l4 = { path = "../../crates/l4" }
+l4re = { path = "../../crates/l4re" }
+l4_sys = { path = "../../crates/l4-sys" }
+libc = "0.2"
+slab = "0.4"
+
+[workspace]

--- a/src/aio_server/src/main.rs
+++ b/src/aio_server/src/main.rs
@@ -1,0 +1,338 @@
+//! POSIX AIO service proxying aio_* calls over L4 IPC.
+
+use core::mem::size_of;
+use l4::sys::{
+    l4_ipc_error, l4_ipc_reply_and_wait, l4_ipc_wait, l4_msgtag, l4_timeout_t, l4_utcb, l4_utcb_br,
+    l4_utcb_mr,
+};
+use l4re::sys::{l4re_env, l4re_env_get_cap};
+use libc::{self, aiocb, c_int, c_void};
+use slab::Slab;
+use std::cmp::min;
+use std::os::unix::io::RawFd;
+
+const BR_WORDS: usize = l4_sys::consts::UtcbConsts::L4_UTCB_GENERIC_BUFFERS_SIZE as usize;
+const BR_DATA_BYTES: usize = (BR_WORDS.saturating_sub(1)) * size_of::<u64>();
+
+mod opcode {
+    pub const AIO_READ: u64 = 0;
+    pub const AIO_WRITE: u64 = 1;
+    pub const AIO_ERROR: u64 = 2;
+    pub const AIO_RETURN: u64 = 3;
+    pub const AIO_CANCEL: u64 = 4;
+    pub const AIO_SUSPEND: u64 = 5;
+    pub const AIO_FSYNC: u64 = 6;
+    pub const LIO_LISTIO: u64 = 7;
+}
+
+#[derive(Debug)]
+enum OperationKind {
+    Read,
+    Write,
+    Fsync,
+}
+
+struct Operation {
+    kind: OperationKind,
+    fd: RawFd,
+    result: isize,
+    error: c_int,
+    buffer: Vec<u8>,
+}
+
+fn encode_errno_raw(err: c_int) -> u64 {
+    (-(err as i64)) as u64
+}
+
+unsafe fn br_clear() {
+    (*l4_utcb_br()).br[0] = 0;
+}
+
+unsafe fn br_bytes_mut() -> (*mut u8, usize) {
+    let br = &mut (*l4_utcb_br()).br;
+    let len = min(br[0] as usize, BR_DATA_BYTES);
+    (br.as_mut_ptr().add(1) as *mut u8, len)
+}
+
+unsafe fn br_bytes() -> (*const u8, usize) {
+    let br = &(*l4_utcb_br()).br;
+    let len = min(br[0] as usize, BR_DATA_BYTES);
+    (br.as_ptr().add(1) as *const u8, len)
+}
+
+unsafe fn read_aiocb(expected: usize) -> Result<aiocb, ()> {
+    if expected == 0 || expected > BR_DATA_BYTES {
+        return Err(());
+    }
+    let (ptr, len) = br_bytes();
+    if len < expected {
+        return Err(());
+    }
+    let mut cb: aiocb = core::mem::zeroed();
+    let dst = &mut cb as *mut aiocb as *mut u8;
+    core::ptr::copy_nonoverlapping(ptr, dst, core::cmp::min(expected, size_of::<aiocb>()));
+    Ok(cb)
+}
+
+fn read_buffer_from_aiocb(cb: &aiocb) -> (usize, libc::off_t) {
+    let len = cb.aio_nbytes as usize;
+    let offset = cb.aio_offset as libc::off_t;
+    (len, offset)
+}
+
+fn perform_read(fd: RawFd, len: usize, offset: libc::off_t) -> Result<(Vec<u8>, isize), c_int> {
+    if len > BR_DATA_BYTES {
+        return Err(libc::EOVERFLOW);
+    }
+    let mut buf = vec![0u8; len];
+    let res = unsafe { libc::pread(fd, buf.as_mut_ptr() as *mut c_void, len, offset) };
+    if res < 0 {
+        let err = unsafe { *libc::__errno_location() };
+        Err(err)
+    } else {
+        let res = res as isize;
+        buf.truncate(res as usize);
+        Ok((buf, res))
+    }
+}
+
+fn perform_write(fd: RawFd, payload: &[u8], offset: libc::off_t) -> Result<isize, c_int> {
+    let res = unsafe { libc::pwrite(fd, payload.as_ptr() as *const c_void, payload.len(), offset) };
+    if res < 0 {
+        let err = unsafe { *libc::__errno_location() };
+        Err(err)
+    } else {
+        Ok(res as isize)
+    }
+}
+
+fn perform_fsync(fd: RawFd, op: c_int) -> Result<isize, c_int> {
+    let res = if op == libc::O_DSYNC {
+        unsafe { libc::fdatasync(fd) }
+    } else {
+        unsafe { libc::fsync(fd) }
+    };
+    if res < 0 {
+        let err = unsafe { *libc::__errno_location() };
+        Err(err)
+    } else {
+        Ok(0)
+    }
+}
+
+fn handle_aio_read(ops: &mut Slab<Operation>, mr: &mut [u64]) {
+    let struct_len = mr[1] as usize;
+    let cb = unsafe { read_aiocb(struct_len) };
+    let cb = match cb {
+        Ok(cb) => cb,
+        Err(_) => {
+            mr[0] = encode_errno_raw(libc::EINVAL);
+            unsafe { br_clear() };
+            return;
+        }
+    };
+
+    let (len, offset) = read_buffer_from_aiocb(&cb);
+    match perform_read(cb.aio_fildes, len, offset) {
+        Ok((buffer, result)) => {
+            let slot = ops.insert(Operation {
+                kind: OperationKind::Read,
+                fd: cb.aio_fildes,
+                result,
+                error: 0,
+                buffer,
+            });
+            mr[0] = slot as u64;
+        }
+        Err(err) => {
+            mr[0] = encode_errno_raw(err);
+        }
+    }
+    unsafe { br_clear() };
+}
+
+fn handle_aio_write(ops: &mut Slab<Operation>, mr: &mut [u64]) {
+    let struct_len = mr[1] as usize;
+    let payload_len = mr[2] as usize;
+    let (ptr, total) = unsafe { br_bytes() };
+    if total < struct_len.saturating_add(payload_len) {
+        mr[0] = encode_errno_raw(libc::EINVAL);
+        unsafe { br_clear() };
+        return;
+    }
+
+    let mut cb: aiocb = unsafe { core::mem::zeroed() };
+    unsafe {
+        core::ptr::copy_nonoverlapping(ptr, &mut cb as *mut _ as *mut u8, core::cmp::min(struct_len, size_of::<aiocb>()));
+    }
+    let payload_ptr = unsafe { ptr.add(struct_len) };
+    let payload = unsafe { std::slice::from_raw_parts(payload_ptr, payload_len) };
+
+    match perform_write(cb.aio_fildes, payload, cb.aio_offset as libc::off_t) {
+        Ok(result) => {
+            let slot = ops.insert(Operation {
+                kind: OperationKind::Write,
+                fd: cb.aio_fildes,
+                result,
+                error: 0,
+                buffer: Vec::new(),
+            });
+            mr[0] = slot as u64;
+        }
+        Err(err) => {
+            mr[0] = encode_errno_raw(err);
+        }
+    }
+    unsafe { br_clear() };
+}
+
+fn handle_aio_fsync(ops: &mut Slab<Operation>, mr: &mut [u64]) {
+    let struct_len = mr[1] as usize;
+    let op_kind = mr[3] as c_int;
+    let cb = unsafe { read_aiocb(struct_len) };
+    let cb = match cb {
+        Ok(cb) => cb,
+        Err(_) => {
+            mr[0] = encode_errno_raw(libc::EINVAL);
+            unsafe { br_clear() };
+            return;
+        }
+    };
+
+    match perform_fsync(cb.aio_fildes, op_kind) {
+        Ok(result) => {
+            let slot = ops.insert(Operation {
+                kind: OperationKind::Fsync,
+                fd: cb.aio_fildes,
+                result,
+                error: 0,
+                buffer: Vec::new(),
+            });
+            mr[0] = slot as u64;
+        }
+        Err(err) => {
+            mr[0] = encode_errno_raw(err);
+        }
+    }
+    unsafe { br_clear() };
+}
+
+fn handle_aio_error(ops: &Slab<Operation>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    if let Some(op) = ops.get(handle) {
+        mr[0] = op.error as u64;
+    } else {
+        mr[0] = encode_errno_raw(libc::EINVAL);
+    }
+    unsafe { br_clear() };
+}
+
+fn handle_aio_return(ops: &mut Slab<Operation>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    if ops.contains(handle) {
+        let op = ops.remove(handle);
+        if op.error != 0 {
+            mr[0] = encode_errno_raw(op.error);
+            unsafe { br_clear() };
+            return;
+        }
+        mr[0] = op.result as u64;
+        match op.kind {
+            OperationKind::Read => {
+                mr[1] = op.buffer.len() as u64;
+                unsafe {
+                    let br = &mut (*l4_utcb_br()).br;
+                    let len = op.buffer.len().min(BR_DATA_BYTES);
+                    br[0] = len as u64;
+                    if len > 0 {
+                        let dst = br.as_mut_ptr().add(1) as *mut u8;
+                        std::ptr::copy_nonoverlapping(op.buffer.as_ptr(), dst, len);
+                    }
+                }
+            }
+            _ => {
+                mr[1] = 0;
+                unsafe { br_clear() };
+            }
+        }
+        return;
+    }
+    mr[0] = encode_errno_raw(libc::EINVAL);
+    unsafe { br_clear() };
+}
+
+fn handle_aio_cancel(ops: &mut Slab<Operation>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    if ops.contains(handle) {
+        ops.remove(handle);
+        mr[0] = libc::AIO_ALLDONE as u64;
+    } else {
+        mr[0] = libc::AIO_ALLDONE as u64;
+    }
+    unsafe { br_clear() };
+}
+
+fn handle_aio_suspend(mr: &mut [u64]) {
+    let _nent = mr[1] as usize;
+    // All operations are completed synchronously for now.
+    mr[0] = 0;
+    unsafe { br_clear() };
+}
+
+fn handle_lio_listio(mr: &mut [u64]) {
+    // This server currently executes list I/O on the client side.
+    mr[0] = encode_errno_raw(libc::ENOSYS);
+    unsafe { br_clear() };
+}
+
+fn main() {
+    unsafe { run() }
+}
+
+unsafe fn run() {
+    let gate = l4re_env_get_cap("global_aio").expect("IPC gate 'global_aio' not provided");
+
+    let gatelabel = 0b1111_0000u64;
+    if l4_ipc_error(
+        l4::l4_rcv_ep_bind_thread(gate, (*l4re_env()).main_thread, gatelabel),
+        l4_utcb(),
+    ) != 0
+    {
+        panic!("failed to bind IPC gate");
+    }
+
+    println!("aio server ready");
+
+    let mut ops: Slab<Operation> = Slab::new();
+    let mut label = 0u64;
+    let mut tag = l4_ipc_wait(l4_utcb(), &mut label, l4_timeout_t { raw: 0 });
+    loop {
+        if l4_ipc_error(tag, l4_utcb()) != 0 {
+            tag = l4_ipc_wait(l4_utcb(), &mut label, l4_timeout_t { raw: 0 });
+            continue;
+        }
+
+        let mr = &mut (*l4_utcb_mr()).mr;
+        match mr[0] {
+            opcode::AIO_READ => handle_aio_read(&mut ops, mr),
+            opcode::AIO_WRITE => handle_aio_write(&mut ops, mr),
+            opcode::AIO_ERROR => handle_aio_error(&ops, mr),
+            opcode::AIO_RETURN => handle_aio_return(&mut ops, mr),
+            opcode::AIO_CANCEL => handle_aio_cancel(&mut ops, mr),
+            opcode::AIO_SUSPEND => handle_aio_suspend(mr),
+            opcode::AIO_FSYNC => handle_aio_fsync(&mut ops, mr),
+            opcode::LIO_LISTIO => handle_lio_listio(mr),
+            _ => {
+                mr[0] = encode_errno_raw(libc::ENOSYS);
+                br_clear();
+            }
+        }
+
+        tag = l4_ipc_reply_and_wait(
+            l4_utcb(),
+            l4_msgtag(0, 2, 0, 0),
+            &mut label,
+            l4_timeout_t { raw: 0 },
+        );
+    }
+}

--- a/src/epoll_server/Cargo.toml
+++ b/src/epoll_server/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "epoll_server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+l4re = { path = "../../crates/l4re" }
+l4 = { path = "../../crates/l4" }
+libc = "0.2"
+slab = "0.4"
+
+[workspace]

--- a/src/epoll_server/src/main.rs
+++ b/src/epoll_server/src/main.rs
@@ -1,0 +1,242 @@
+//! Epoll server for L4Re.
+//!
+//! This server exposes a tiny subset of Linux' epoll interface over L4 IPC.
+//! Clients communicate with the server via the `global_epoll` capability. The
+//! protocol mirrors the operations of `epoll_create1`, `epoll_ctl` and
+//! `epoll_wait` in a minimal fashion. The server keeps epoll instances in user
+//! space and uses the host's epoll implementation to drive readiness.
+
+use core::mem::size_of;
+use l4_sys::{l4_ipc_error, l4_msgtag, l4_utcb, l4_utcb_br};
+use l4re::sys::{l4re_env, l4re_env_get_cap};
+use libc::{self, c_int};
+use slab::Slab;
+use std::io;
+use std::os::unix::io::RawFd;
+
+/// Maximum number of buffer register words available.
+const BR_WORDS: usize = l4_sys::consts::UtcbConsts::L4_UTCB_GENERIC_BUFFERS_SIZE as usize;
+/// Reserve the first word for the payload length when serialising replies.
+const BR_DATA_BYTES: usize = (BR_WORDS.saturating_sub(1)) * size_of::<u64>();
+/// Size of a single `libc::epoll_event` structure.
+const EPOLL_EVENT_SIZE: usize = size_of::<libc::epoll_event>();
+/// Maximum number of epoll events that fit into the UTCB buffer registers.
+const MAX_SERIALISED_EVENTS: usize = if EPOLL_EVENT_SIZE == 0 {
+    0
+} else {
+    BR_DATA_BYTES / EPOLL_EVENT_SIZE
+};
+
+/// Operation codes understood by the server.
+mod opcode {
+    pub const CREATE1: u64 = 0;
+    pub const CTL: u64 = 1;
+    pub const WAIT: u64 = 2;
+    pub const CLOSE: u64 = 3;
+}
+
+/// Representation of an epoll instance maintained by the server.
+struct EpollInstance {
+    fd: RawFd,
+}
+
+impl Drop for EpollInstance {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.fd);
+        }
+    }
+}
+
+fn main() {
+    unsafe { run() }
+}
+
+/// Convert the last OS error into a negative errno encoded as `u64`.
+fn encode_errno() -> u64 {
+    let err = io::Error::last_os_error()
+        .raw_os_error()
+        .unwrap_or(libc::EIO);
+    (-(err as i64)) as u64
+}
+
+/// Write an empty payload into the UTCB buffer registers.
+unsafe fn br_clear() {
+    let br = &mut (*l4_utcb_br()).br;
+    br[0] = 0;
+}
+
+/// Read a single epoll event from the buffer registers.
+unsafe fn br_read_event() -> Option<libc::epoll_event> {
+    if EPOLL_EVENT_SIZE == 0 {
+        return None;
+    }
+    let br = &(*l4_utcb_br()).br;
+    let len = br[0] as usize;
+    if len < EPOLL_EVENT_SIZE {
+        return None;
+    }
+    let ptr = br.as_ptr().add(1) as *const u8;
+    let mut event = libc::epoll_event { events: 0, u64: 0 };
+    std::ptr::copy_nonoverlapping(ptr, &mut event as *mut _ as *mut u8, EPOLL_EVENT_SIZE);
+    Some(event)
+}
+
+/// Serialise a slice of epoll events into the buffer registers.
+unsafe fn br_write_events(events: &[libc::epoll_event]) {
+    let count = events.len().min(MAX_SERIALISED_EVENTS);
+    let br = &mut (*l4_utcb_br()).br;
+    let bytes = count * EPOLL_EVENT_SIZE;
+    br[0] = bytes as u64;
+    if bytes == 0 {
+        return;
+    }
+    let dst = br.as_mut_ptr().add(1) as *mut u8;
+    std::ptr::copy_nonoverlapping(events.as_ptr() as *const u8, dst, bytes);
+}
+
+/// Handle an `epoll_ctl` request.
+fn handle_ctl(
+    instances: &mut Slab<EpollInstance>,
+    mr: &mut [u64; l4_sys::consts::UtcbConsts::L4_UTCB_MR_COUNT as usize],
+) {
+    let handle = mr[1] as usize;
+    let op = mr[2] as c_int;
+    let target_fd = mr[3] as c_int;
+
+    let Some(instance) = instances.get(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        unsafe { br_clear() };
+        return;
+    };
+
+    let res = unsafe {
+        match op {
+            libc::EPOLL_CTL_DEL => {
+                libc::epoll_ctl(instance.fd, op, target_fd, std::ptr::null_mut())
+            }
+            _ => {
+                let Some(mut event) = (unsafe { br_read_event() }) else {
+                    return mr[0] = (-(libc::EINVAL as i64)) as u64;
+                };
+                libc::epoll_ctl(instance.fd, op, target_fd, &mut event)
+            }
+        }
+    };
+
+    mr[0] = if res < 0 { encode_errno() } else { 0 };
+    unsafe { br_clear() };
+}
+
+/// Handle an `epoll_wait` request.
+fn handle_wait(
+    instances: &mut Slab<EpollInstance>,
+    mr: &mut [u64; l4_sys::consts::UtcbConsts::L4_UTCB_MR_COUNT as usize],
+) {
+    let handle = mr[1] as usize;
+    let maxevents = mr[2] as c_int;
+    let timeout = mr[3] as c_int;
+
+    let Some(instance) = instances.get(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        unsafe { br_clear() };
+        return;
+    };
+
+    if maxevents <= 0 {
+        mr[0] = (-(libc::EINVAL as i64)) as u64;
+        unsafe { br_clear() };
+        return;
+    }
+
+    if MAX_SERIALISED_EVENTS == 0 {
+        mr[0] = (-(libc::EOVERFLOW as i64)) as u64;
+        unsafe { br_clear() };
+        return;
+    }
+
+    let limit = maxevents.min(MAX_SERIALISED_EVENTS as c_int) as usize;
+    let mut events: Vec<libc::epoll_event> = Vec::with_capacity(limit);
+    let res =
+        unsafe { libc::epoll_wait(instance.fd, events.as_mut_ptr(), limit as c_int, timeout) };
+
+    if res < 0 {
+        mr[0] = encode_errno();
+        unsafe { br_clear() };
+        return;
+    }
+
+    unsafe { events.set_len(res as usize) };
+    unsafe { br_write_events(&events) };
+    mr[0] = res as u64;
+}
+
+/// Handle closing of an epoll instance.
+fn handle_close(
+    instances: &mut Slab<EpollInstance>,
+    mr: &mut [u64; l4_sys::consts::UtcbConsts::L4_UTCB_MR_COUNT as usize],
+) {
+    let handle = mr[1] as usize;
+    if instances.contains(handle) {
+        instances.remove(handle);
+        mr[0] = 0;
+    } else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+    }
+    unsafe { br_clear() };
+}
+
+/// Main server loop performing IPC dispatch.
+unsafe fn run() {
+    let gate = l4re_env_get_cap("global_epoll").expect("IPC gate 'global_epoll' not provided");
+
+    let gatelabel = 0b1111_0000u64;
+    if l4_ipc_error(
+        l4::l4_rcv_ep_bind_thread(gate, (*l4re_env()).main_thread, gatelabel),
+        l4_utcb(),
+    ) != 0
+    {
+        panic!("failed to bind IPC gate");
+    }
+
+    println!("epoll server ready");
+
+    let mut instances: Slab<EpollInstance> = Slab::new();
+    let mut label = 0u64;
+    let mut tag = l4::l4_ipc_wait(l4_utcb(), &mut label, l4::l4_timeout_t { raw: 0 });
+    loop {
+        if l4_ipc_error(tag, l4_utcb()) != 0 {
+            tag = l4::l4_ipc_wait(l4_utcb(), &mut label, l4::l4_timeout_t { raw: 0 });
+            continue;
+        }
+
+        let mr = &mut (*l4::l4_utcb_mr()).mr;
+        match mr[0] {
+            opcode::CREATE1 => {
+                let flags = mr[1] as c_int;
+                let fd = unsafe { libc::epoll_create1(flags) };
+                if fd < 0 {
+                    mr[0] = encode_errno();
+                } else {
+                    let slot = instances.insert(EpollInstance { fd });
+                    mr[0] = slot as u64;
+                }
+                br_clear();
+            }
+            opcode::CTL => handle_ctl(&mut instances, mr),
+            opcode::WAIT => handle_wait(&mut instances, mr),
+            opcode::CLOSE => handle_close(&mut instances, mr),
+            _ => {
+                mr[0] = (-(libc::ENOSYS as i64)) as u64;
+                br_clear();
+            }
+        }
+
+        tag = l4::l4_ipc_reply_and_wait(
+            l4_utcb(),
+            l4_msgtag(0, 1, 0, 0),
+            &mut label,
+            l4::l4_timeout_t { raw: 0 },
+        );
+    }
+}

--- a/src/fd_server/Cargo.toml
+++ b/src/fd_server/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fd_server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+l4re = { path = "../../crates/l4re" }
+l4 = { path = "../../crates/l4" }
+libc = "0.2"
+slab = "0.4"
+
+[workspace]

--- a/src/fd_server/src/main.rs
+++ b/src/fd_server/src/main.rs
@@ -1,0 +1,593 @@
+//! Service providing Linux descriptor helper APIs (eventfd, timerfd,
+//! signalfd, and inotify) over L4 IPC.
+
+use core::mem::size_of;
+use l4::sys::{
+    l4_ipc_error, l4_ipc_reply_and_wait, l4_ipc_wait, l4_msgtag, l4_timeout_t, l4_utcb,
+    l4_utcb_br, l4_utcb_mr,
+};
+use l4re::sys::{l4re_env, l4re_env_get_cap};
+use libc::{self, c_int, c_long, c_uint, c_void, clockid_t, itimerspec, sigset_t};
+use slab::Slab;
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::io;
+use std::os::unix::io::RawFd;
+
+/// Size of the UTCB buffer register payload in bytes (minus one length word).
+const BR_WORDS: usize = l4_sys::consts::UtcbConsts::L4_UTCB_GENERIC_BUFFERS_SIZE as usize;
+const BR_DATA_BYTES: usize = (BR_WORDS.saturating_sub(1)) * size_of::<u64>();
+
+mod opcode {
+    pub const EVENTFD_CREATE: u64 = 0;
+    pub const EVENTFD_READ: u64 = 1;
+    pub const EVENTFD_WRITE: u64 = 2;
+    pub const EVENTFD_CLOSE: u64 = 3;
+
+    pub const TIMERFD_CREATE: u64 = 16;
+    pub const TIMERFD_SETTIME: u64 = 17;
+    pub const TIMERFD_GETTIME: u64 = 18;
+    pub const TIMERFD_READ: u64 = 19;
+    pub const TIMERFD_CLOSE: u64 = 20;
+
+    pub const SIGNALFD_CREATE: u64 = 32;
+    pub const SIGNALFD_READ: u64 = 33;
+    pub const SIGNALFD_CLOSE: u64 = 34;
+
+    pub const INOTIFY_INIT: u64 = 48;
+    pub const INOTIFY_ADD_WATCH: u64 = 49;
+    pub const INOTIFY_RM_WATCH: u64 = 50;
+    pub const INOTIFY_READ: u64 = 51;
+    pub const INOTIFY_CLOSE: u64 = 52;
+}
+
+struct Eventfd {
+    fd: RawFd,
+}
+
+impl Drop for Eventfd {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.fd);
+        }
+    }
+}
+
+struct Timerfd {
+    fd: RawFd,
+}
+
+impl Drop for Timerfd {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.fd);
+        }
+    }
+}
+
+struct Signalfd {
+    fd: RawFd,
+}
+
+impl Drop for Signalfd {
+    fn drop(&mut self) {
+        unsafe { libc::close(self.fd) };
+    }
+}
+
+struct Inotify {
+    fd: RawFd,
+    watches: HashMap<i32, i32>,
+}
+
+impl Drop for Inotify {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.fd);
+        }
+        self.watches.clear();
+    }
+}
+
+fn main() {
+    unsafe { run() }
+}
+
+fn encode_errno() -> u64 {
+    let err = io::Error::last_os_error()
+        .raw_os_error()
+        .unwrap_or(libc::EIO);
+    (-(err as i64)) as u64
+}
+
+unsafe fn br_clear() {
+    (*l4_utcb_br()).br[0] = 0;
+}
+
+unsafe fn br_write_bytes(data: &[u8]) {
+    let len = data.len().min(BR_DATA_BYTES);
+    let br = &mut (*l4_utcb_br()).br;
+    br[0] = len as u64;
+    if len == 0 {
+        return;
+    }
+    let dst = br.as_mut_ptr().add(1) as *mut u8;
+    std::ptr::copy_nonoverlapping(data.as_ptr(), dst, len);
+}
+
+unsafe fn br_read_bytes(buf: &mut Vec<u8>) {
+    let br = &(*l4_utcb_br()).br;
+    let len = (br[0] as usize).min(BR_DATA_BYTES);
+    buf.clear();
+    buf.reserve(len);
+    let src = br.as_ptr().add(1) as *const u8;
+    buf.extend_from_slice(std::slice::from_raw_parts(src, len));
+}
+
+unsafe fn br_read_exact<const N: usize>() -> Option<[u8; N]> {
+    if N == 0 {
+        return Some([0; N]);
+    }
+    let br = &(*l4_utcb_br()).br;
+    let len = br[0] as usize;
+    if len < N {
+        return None;
+    }
+    let mut out = [0u8; N];
+    let src = br.as_ptr().add(1) as *const u8;
+    std::ptr::copy_nonoverlapping(src, out.as_mut_ptr(), N);
+    Some(out)
+}
+
+unsafe fn read_itimerspec() -> Option<itimerspec> {
+    let bytes = br_read_exact::<{ size_of::<itimerspec>() }>()?;
+    let mut spec = itimerspec {
+        it_interval: libc::timespec { tv_sec: 0, tv_nsec: 0 },
+        it_value: libc::timespec { tv_sec: 0, tv_nsec: 0 },
+    };
+    std::ptr::copy_nonoverlapping(
+        bytes.as_ptr(),
+        &mut spec as *mut _ as *mut u8,
+        size_of::<itimerspec>(),
+    );
+    Some(spec)
+}
+
+unsafe fn write_itimerspec(spec: &itimerspec) {
+    let mut bytes = [0u8; size_of::<itimerspec>()];
+    std::ptr::copy_nonoverlapping(
+        spec as *const _ as *const u8,
+        bytes.as_mut_ptr(),
+        size_of::<itimerspec>(),
+    );
+    br_write_bytes(&bytes);
+}
+
+unsafe fn read_sigset(expected: usize) -> Option<Vec<u8>> {
+    let mut buf = Vec::new();
+    br_read_bytes(&mut buf);
+    if buf.len() != expected {
+        return None;
+    }
+    Some(buf)
+}
+
+unsafe fn read_string() -> Option<CString> {
+    let mut buf = Vec::new();
+    br_read_bytes(&mut buf);
+    if buf.last().copied() != Some(0) {
+        buf.push(0);
+    }
+    CString::new(buf).ok()
+}
+
+unsafe fn handle_eventfd_create(eventfds: &mut Slab<Eventfd>, mr: &mut [u64]) {
+    let initval = mr[1] as c_uint;
+    let flags = mr[2] as c_int;
+    let fd = libc::eventfd(initval, flags);
+    if fd < 0 {
+        mr[0] = encode_errno();
+        return;
+    }
+    let slot = eventfds.insert(Eventfd { fd });
+    mr[0] = slot as u64;
+    br_clear();
+}
+
+unsafe fn handle_eventfd_read(eventfds: &mut Slab<Eventfd>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    let Some(entry) = eventfds.get(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        br_clear();
+        return;
+    };
+    let mut value: u64 = 0;
+    let res = libc::read(
+        entry.fd,
+        &mut value as *mut u64 as *mut c_void,
+        size_of::<u64>(),
+    );
+    if res != size_of::<u64>() as isize {
+        mr[0] = encode_errno();
+        br_clear();
+        return;
+    }
+    mr[0] = 0;
+    mr[1] = value;
+    br_clear();
+}
+
+unsafe fn handle_eventfd_write(eventfds: &mut Slab<Eventfd>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    let value = mr[2];
+    let Some(entry) = eventfds.get(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        br_clear();
+        return;
+    };
+    let res = libc::write(
+        entry.fd,
+        &value as *const u64 as *const c_void,
+        size_of::<u64>(),
+    );
+    if res != size_of::<u64>() as isize {
+        mr[0] = encode_errno();
+    } else {
+        mr[0] = 0;
+    }
+    br_clear();
+}
+
+unsafe fn handle_eventfd_close(eventfds: &mut Slab<Eventfd>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    if eventfds.contains(handle) {
+        eventfds.remove(handle);
+        mr[0] = 0;
+    } else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+    }
+    br_clear();
+}
+
+unsafe fn handle_timerfd_create(timerfds: &mut Slab<Timerfd>, mr: &mut [u64]) {
+    let clockid = mr[1] as clockid_t;
+    let flags = mr[2] as c_int;
+    let fd = libc::timerfd_create(clockid, flags);
+    if fd < 0 {
+        mr[0] = encode_errno();
+        br_clear();
+        return;
+    }
+    let slot = timerfds.insert(Timerfd { fd });
+    mr[0] = slot as u64;
+    br_clear();
+}
+
+unsafe fn handle_timerfd_settime(timerfds: &mut Slab<Timerfd>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    let flags = mr[2] as c_int;
+    let want_old = mr[3] != 0;
+    let Some(entry) = timerfds.get(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        br_clear();
+        return;
+    };
+    let Some(new_value) = read_itimerspec() else {
+        mr[0] = (-(libc::EINVAL as i64)) as u64;
+        br_clear();
+        return;
+    };
+    let mut old_value = itimerspec {
+        it_interval: libc::timespec { tv_sec: 0, tv_nsec: 0 },
+        it_value: libc::timespec { tv_sec: 0, tv_nsec: 0 },
+    };
+    let old_ptr = if want_old {
+        &mut old_value as *mut itimerspec
+    } else {
+        core::ptr::null_mut()
+    };
+    let res = libc::timerfd_settime(entry.fd, flags, &new_value, old_ptr);
+    if res < 0 {
+        mr[0] = encode_errno();
+        br_clear();
+        return;
+    }
+    mr[0] = 0;
+    if want_old {
+        write_itimerspec(&old_value);
+    } else {
+        br_clear();
+    }
+}
+
+unsafe fn handle_timerfd_gettime(timerfds: &mut Slab<Timerfd>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    let Some(entry) = timerfds.get(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        br_clear();
+        return;
+    };
+    let mut cur = itimerspec {
+        it_interval: libc::timespec { tv_sec: 0, tv_nsec: 0 },
+        it_value: libc::timespec { tv_sec: 0, tv_nsec: 0 },
+    };
+    let res = libc::timerfd_gettime(entry.fd, &mut cur);
+    if res < 0 {
+        mr[0] = encode_errno();
+        br_clear();
+        return;
+    }
+    mr[0] = 0;
+    write_itimerspec(&cur);
+}
+
+unsafe fn handle_timerfd_read(timerfds: &mut Slab<Timerfd>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    let Some(entry) = timerfds.get(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        br_clear();
+        return;
+    };
+    let mut expirations: u64 = 0;
+    let res = libc::read(
+        entry.fd,
+        &mut expirations as *mut u64 as *mut c_void,
+        size_of::<u64>(),
+    );
+    if res != size_of::<u64>() as isize {
+        mr[0] = encode_errno();
+        br_clear();
+        return;
+    }
+    mr[0] = 0;
+    mr[1] = expirations;
+    br_clear();
+}
+
+unsafe fn handle_timerfd_close(timerfds: &mut Slab<Timerfd>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    if timerfds.contains(handle) {
+        timerfds.remove(handle);
+        mr[0] = 0;
+    } else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+    }
+    br_clear();
+}
+
+unsafe fn handle_signalfd_create(signalfds: &mut Slab<Signalfd>, mr: &mut [u64]) {
+    let target = mr[1] as isize;
+    let flags = mr[2] as c_int;
+    let size = mr[3] as usize;
+    let Some(mask_bytes) = read_sigset(size) else {
+        mr[0] = (-(libc::EINVAL as i64)) as u64;
+        br_clear();
+        return;
+    };
+    let raw_fd = if target >= 0 {
+        let Some(existing) = signalfds.get(target as usize) else {
+            mr[0] = (-(libc::EBADF as i64)) as u64;
+            br_clear();
+            return;
+        };
+        existing.fd
+    } else {
+        -1
+    };
+    let res_fd = libc::syscall(
+        libc::SYS_signalfd4,
+        raw_fd,
+        mask_bytes.as_ptr() as *const sigset_t,
+        size,
+        flags,
+    ) as c_int;
+    if res_fd < 0 {
+        mr[0] = encode_errno();
+        br_clear();
+        return;
+    }
+    if target >= 0 {
+        mr[0] = 0;
+        br_clear();
+        return;
+    }
+    let slot = signalfds.insert(Signalfd { fd: res_fd });
+    mr[0] = slot as u64;
+    br_clear();
+}
+
+unsafe fn handle_signalfd_read(signalfds: &mut Slab<Signalfd>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    let max_bytes = (mr[2] as usize).min(BR_DATA_BYTES);
+    let Some(entry) = signalfds.get(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        br_clear();
+        return;
+    };
+    if max_bytes == 0 {
+        mr[0] = (-(libc::EINVAL as i64)) as u64;
+        br_clear();
+        return;
+    }
+    let mut buf = vec![0u8; max_bytes];
+    let res = libc::read(entry.fd, buf.as_mut_ptr() as *mut c_void, max_bytes);
+    if res < 0 {
+        mr[0] = encode_errno();
+        br_clear();
+        return;
+    }
+    buf.truncate(res as usize);
+    br_write_bytes(&buf);
+    mr[0] = res as u64;
+}
+
+unsafe fn handle_signalfd_close(signalfds: &mut Slab<Signalfd>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    if signalfds.contains(handle) {
+        signalfds.remove(handle);
+        mr[0] = 0;
+    } else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+    }
+    br_clear();
+}
+
+unsafe fn handle_inotify_init(inotifies: &mut Slab<Inotify>, mr: &mut [u64]) {
+    let flags = mr[1] as c_int;
+    let fd = libc::inotify_init1(flags);
+    if fd < 0 {
+        mr[0] = encode_errno();
+        br_clear();
+        return;
+    }
+    let slot = inotifies.insert(Inotify {
+        fd,
+        watches: HashMap::new(),
+    });
+    mr[0] = slot as u64;
+    br_clear();
+}
+
+unsafe fn handle_inotify_add_watch(inotifies: &mut Slab<Inotify>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    let mask = mr[2] as u32;
+    let Some(entry) = inotifies.get_mut(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        br_clear();
+        return;
+    };
+    let Some(path) = read_string() else {
+        mr[0] = (-(libc::EINVAL as i64)) as u64;
+        br_clear();
+        return;
+    };
+    let wd = libc::inotify_add_watch(entry.fd, path.as_ptr(), mask);
+    if wd < 0 {
+        mr[0] = encode_errno();
+        br_clear();
+        return;
+    }
+    entry.watches.insert(wd, wd);
+    mr[0] = wd as u64;
+    br_clear();
+}
+
+unsafe fn handle_inotify_rm_watch(inotifies: &mut Slab<Inotify>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    let wd = mr[2] as i32;
+    let Some(entry) = inotifies.get_mut(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        br_clear();
+        return;
+    };
+    let res = libc::inotify_rm_watch(entry.fd, wd);
+    if res < 0 {
+        mr[0] = encode_errno();
+    } else {
+        mr[0] = 0;
+        entry.watches.remove(&wd);
+    }
+    br_clear();
+}
+
+unsafe fn handle_inotify_read(inotifies: &mut Slab<Inotify>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    let max_bytes = (mr[2] as usize).min(BR_DATA_BYTES);
+    let Some(entry) = inotifies.get(handle) else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+        br_clear();
+        return;
+    };
+    if max_bytes == 0 {
+        mr[0] = (-(libc::EINVAL as i64)) as u64;
+        br_clear();
+        return;
+    }
+    let mut buf = vec![0u8; max_bytes];
+    let res = libc::read(entry.fd, buf.as_mut_ptr() as *mut c_void, max_bytes);
+    if res < 0 {
+        mr[0] = encode_errno();
+        br_clear();
+        return;
+    }
+    buf.truncate(res as usize);
+    br_write_bytes(&buf);
+    mr[0] = res as u64;
+}
+
+unsafe fn handle_inotify_close(inotifies: &mut Slab<Inotify>, mr: &mut [u64]) {
+    let handle = mr[1] as usize;
+    if inotifies.contains(handle) {
+        inotifies.remove(handle);
+        mr[0] = 0;
+    } else {
+        mr[0] = (-(libc::EBADF as i64)) as u64;
+    }
+    br_clear();
+}
+
+unsafe fn run() {
+    let gate = l4re_env_get_cap("global_fd").expect("IPC gate 'global_fd' not provided");
+
+    let label = 0b1111_0101u64;
+    if l4_ipc_error(
+        l4::l4_rcv_ep_bind_thread(gate, (*l4re_env()).main_thread, label),
+        l4_utcb(),
+    ) != 0
+    {
+        panic!("failed to bind IPC gate");
+    }
+
+    println!("fd helper server ready");
+
+    let mut eventfds = Slab::new();
+    let mut timerfds = Slab::new();
+    let mut signalfds = Slab::new();
+    let mut inotifies = Slab::new();
+
+    let mut badge = 0u64;
+    let mut tag = l4_ipc_wait(l4_utcb(), &mut badge, l4_timeout_t { raw: 0 });
+
+    loop {
+        if l4_ipc_error(tag, l4_utcb()) != 0 {
+            tag = l4_ipc_wait(l4_utcb(), &mut badge, l4_timeout_t { raw: 0 });
+            continue;
+        }
+
+        let mr = &mut (*l4_utcb_mr()).mr;
+        match mr[0] {
+            opcode::EVENTFD_CREATE => handle_eventfd_create(&mut eventfds, mr),
+            opcode::EVENTFD_READ => handle_eventfd_read(&mut eventfds, mr),
+            opcode::EVENTFD_WRITE => handle_eventfd_write(&mut eventfds, mr),
+            opcode::EVENTFD_CLOSE => handle_eventfd_close(&mut eventfds, mr),
+
+            opcode::TIMERFD_CREATE => handle_timerfd_create(&mut timerfds, mr),
+            opcode::TIMERFD_SETTIME => handle_timerfd_settime(&mut timerfds, mr),
+            opcode::TIMERFD_GETTIME => handle_timerfd_gettime(&mut timerfds, mr),
+            opcode::TIMERFD_READ => handle_timerfd_read(&mut timerfds, mr),
+            opcode::TIMERFD_CLOSE => handle_timerfd_close(&mut timerfds, mr),
+
+            opcode::SIGNALFD_CREATE => handle_signalfd_create(&mut signalfds, mr),
+            opcode::SIGNALFD_READ => handle_signalfd_read(&mut signalfds, mr),
+            opcode::SIGNALFD_CLOSE => handle_signalfd_close(&mut signalfds, mr),
+
+            opcode::INOTIFY_INIT => handle_inotify_init(&mut inotifies, mr),
+            opcode::INOTIFY_ADD_WATCH => handle_inotify_add_watch(&mut inotifies, mr),
+            opcode::INOTIFY_RM_WATCH => handle_inotify_rm_watch(&mut inotifies, mr),
+            opcode::INOTIFY_READ => handle_inotify_read(&mut inotifies, mr),
+            opcode::INOTIFY_CLOSE => handle_inotify_close(&mut inotifies, mr),
+
+            _ => {
+                mr[0] = (-(libc::ENOSYS as c_long)) as u64;
+                br_clear();
+            }
+        }
+
+        tag = l4_ipc_reply_and_wait(
+            l4_utcb(),
+            l4_msgtag(0, 1, 0, 0),
+            &mut badge,
+            l4_timeout_t { raw: 0 },
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated aio_server binary that proxies POSIX aio operations over L4 IPC and manages completion state
- package the new server in the image build and expose it via systemd units and a global_aio loader capability
- extend l4re-libc with C-side aio_* shims that talk to the service through the L4 buffer/message registers

## Testing
- cargo check --manifest-path src/aio_server/Cargo.toml *(fails: requires L4 headers such as pthread-l4.h in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d783d33004832fb9691576799892ce