### PR TITLE
Stage root filesystem image alongside boot image

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ scripts/build.sh --no-clean          # build L4Re, systemd, Bash, and stage the 
 scripts/runqemu.sh                   # boot the freshest image under QEMU
 ```
 
-The bootable binary is staged under `distribution/images/`; for example the
-`bootstrap_bash_arm_virt.uimage` target boots into systemd, which in turn starts
-the file server, network server, and an interactive Bash console.
+Boot artifacts are staged under `distribution/images/`. The
+`lsb_root.img` root filesystem image contains the packaged Bash shell and
+systemd (installed as `/sbin/init`), while the
+`bootstrap_bash_arm_virt.uimage` boot image loads that filesystem together with
+the required L4Re components to start the file server, network server, and an
+interactive Bash console.
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1205,6 +1205,13 @@ EOF
       echo "Staging image $base from $file into $distribution_images_dir"
       cp -f "$file" "$dest_path"
     done
+
+    if [ -f "$lsb_img" ]; then
+      base="$(basename "$lsb_img")"
+      dest_path="$distribution_images_dir/$base"
+      echo "Staging root filesystem $base from $lsb_img into $distribution_images_dir"
+      cp -f "$lsb_img" "$dest_path"
+    fi
   }
 
   stage_bootable_images


### PR DESCRIPTION
## Summary
- stage the generated lsb_root.img root filesystem into distribution/images alongside the bootable uimage
- document that lsb_root.img carries bash and systemd while the bootstrap image loads it

## Testing
- Not run (not requested)
