### PR TITLE
Add modules list entry for lsb root image

### DIFF
--- a/config/modules.list
+++ b/config/modules.list
@@ -1,0 +1,9 @@
+entry bash
+kernel fiasco -serial_esc
+roottask moe rom/ned -c rom/bash.cfg
+module sigma0
+module moe
+module l4re
+module ned
+module bash.cfg
+module lsb_root.img

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -962,6 +962,7 @@ build_image_component() {
   mkdir -p "$(dirname "$lsb_img")"
   dd if=/dev/zero of="$lsb_img" bs=1M count=180
   mke2fs -F "$lsb_img" >/dev/null
+  ln -sf "$(pwd)/$lsb_img" config/lsb_root.img
   local d
   for d in /bin /etc /sbin /usr /usr/bin; do
     debugfs -w -R "mkdir $d" "$lsb_img" >/dev/null


### PR DESCRIPTION
## Summary
- add a modules.list entry that boots the systemd/bash stack and includes the lsb_root.img payload
- expose the freshly generated lsb_root.img under config/ so the L4 image build can pick it up

## Testing
- not run (not requested)
